### PR TITLE
Update to python 3.7 and latest nuklear

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,115 @@
-_nuklear.c
-_nuklear.o
-_nuklear.so
-nuklear.defs
-*.pyc
-/.eggs/*
-/build/*
-/pynk.egg-info/*
-/dist/*
-/.idea/*
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: clean
+
+OUT_HEADER=nuklear_preprocessed.h
+SOURCE_HEADER=nuklear/nuklear.h
+
+$(OUT_HEADER): $(SOURCE_HEADER)
+	$(CC) -E -DNK_INCLUDE_VERTEX_BUFFER_OUTPUT -DNK_INCLUDE_DEFAULT_ALLOCATOR $(SOURCE_HEADER) > $(OUT_HEADER)
+	sed -i '/_dummy_array/d' ./$(OUT_HEADER)
+
+clean:
+	-rm $(OUT_HEADER)

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ The package on pypi should work: https://pypi.python.org/pypi/pynk
 
 Otherwise
 
-``python2 setup.py install``
+``python setup.py install``
 
 in the git repository should do it.
 
@@ -40,13 +40,6 @@ Dependencies
 ------------
 
 - cffi, a Python library.
-- pcpp, a C preprocessor written in Python.
-
-As such you will need a C compiler installed if you want to build the library.
-
-Note that at present the `pcpp` in pypi won't cut it, because in order to
-preprocess nuklear.h we rely on a fix that has not (as of writing) yet been
-integrated.  You will have to install the one in my github fork.
 
 For the pygame integration code, `pygame` is necessary, but it's not a
 requirement for installation or to use the binding.

--- a/bin/version.py
+++ b/bin/version.py
@@ -5,7 +5,7 @@ python version.py (--major|--minor|--patch)
 """
 
 
-from __future__ import print_function
+
 
 
 import re

--- a/demo/demo.py
+++ b/demo/demo.py
@@ -1,15 +1,16 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 A demo of the nuklear-cffi binding.
 """
 
 import pygame
+from overview import Overview
 
 import pynk
 import pynk.nkpygame
 
-from overview import Overview
+#from overview import Overview
 
 if __name__ == '__main__':
 
@@ -24,18 +25,18 @@ if __name__ == '__main__':
     prop = pynk.ffi.new("int*", 0)
     winflags = 0
     running = True
-    flags = [ (pynk.lib.NK_WINDOW_BORDER, "Border"),
-              (pynk.lib.NK_WINDOW_MOVABLE, "Movable"),
-              (pynk.lib.NK_WINDOW_SCALABLE, "Scalable"),
-              (pynk.lib.NK_WINDOW_CLOSABLE, "Scrollable"),
-              (pynk.lib.NK_WINDOW_MINIMIZABLE, "Minimizable"),
-              (pynk.lib.NK_WINDOW_TITLE, "Title") ]
+    flags = [ (pynk.lib.NK_WINDOW_BORDER, "Border".encode('utf-8')),
+              (pynk.lib.NK_WINDOW_MOVABLE, "Movable".encode('utf-8')),
+              (pynk.lib.NK_WINDOW_SCALABLE, "Scalable".encode('utf-8')),
+              (pynk.lib.NK_WINDOW_CLOSABLE, "Scrollable".encode('utf-8')),
+              (pynk.lib.NK_WINDOW_MINIMIZABLE, "Minimizable".encode('utf-8')),
+              (pynk.lib.NK_WINDOW_TITLE, "Title".encode('utf-8')) ]
 
     # Initialise nuklear
     font = pynk.nkpygame.NkPygameFont(pygame.font.SysFont("Consolas", 14))
     with pynk.nkpygame.NkPygame(font) as nkpy:
-
         overview = Overview()
+
         while running:
 
             # Handle input.
@@ -48,17 +49,17 @@ if __name__ == '__main__':
             nkpy.handle_events(events)
 
             # Show the demo GUI.
-            if pynk.lib.nk_begin(nkpy.ctx, "Demo", pynk.lib.nk_rect(50, 50, 300, 300), winflags):
+            if pynk.lib.nk_begin(nkpy.ctx, "Demo".encode('utf-8'), pynk.lib.nk_rect(50, 50, 300, 300), winflags):
                 pynk.lib.nk_layout_row_static(nkpy.ctx, 30, 80, 1)
-                if pynk.lib.nk_button_label(nkpy.ctx, "quit"):
+                if pynk.lib.nk_button_label(nkpy.ctx, "quit".encode('utf-8')):
                     running = False
                 pynk.lib.nk_layout_row_dynamic(nkpy.ctx, 30, 2)
-                if pynk.lib.nk_option_label(nkpy.ctx, "easy", op == EASY): 
+                if pynk.lib.nk_option_label(nkpy.ctx, "easy".encode('utf-8'), op == EASY): 
                     op = EASY
-                if pynk.lib.nk_option_label(nkpy.ctx, "hard", op == HARD): 
+                if pynk.lib.nk_option_label(nkpy.ctx, "hard".encode('utf-8'), op == HARD): 
                     op = HARD
                 pynk.lib.nk_layout_row_dynamic(nkpy.ctx, 22, 1)
-                pynk.lib.nk_property_int(nkpy.ctx, "Compression:", 0, prop, 100, 10, 1)
+                pynk.lib.nk_property_int(nkpy.ctx, "Compression:".encode('utf-8'), 0, prop, 100, 10, 1)
                 for flag in flags:
                     pynk.lib.nk_layout_row_dynamic(nkpy.ctx, 22, 1)
                     if pynk.lib.nk_check_label(nkpy.ctx, flag[1], winflags & flag[0]): 

--- a/demo/overview.py
+++ b/demo/overview.py
@@ -41,8 +41,8 @@ import math
 import inspect
 import sys
 
-INT_MAX = sys.maxint
-INT_MIN = -sys.maxint - 1
+INT_MAX = sys.maxsize
+INT_MIN = -sys.maxsize - 1
 
 class Overview(object):
     """
@@ -81,13 +81,13 @@ class Overview(object):
          there's nothing we can do about the first thing - we just have to pick 
          our names carefully.
         """
-        if not hasattr(self, name):
+        if not hasattr(self, name.decode('utf-8')):
             value = initialiser
             if callable(value):
                 value = value()
             if ctype is not None:
-                value = pynk.ffi.new(ctype, value)
-            setattr(self, name, value)
+                value = pynk.ffi.new(ctype.decode('utf-8'), value)
+            setattr(self, name.decode('utf-8'), value)
 
     def declare_string_array(self, name, lst):
         """ 
@@ -98,13 +98,13 @@ class Overview(object):
         """
         keepalive = [pynk.ffi.new("const char[]", s) for s in lst]
         self.__strings += keepalive
-        self.declare(name, keepalive, "const char*[]")
+        self.declare(name, keepalive, "const char*[]".encode('utf-8'))
 
     def declare_string_buffers(self, name, num_strings, string_length):
         """ Method to declare an array of string buffers. """
-        keepalive = [pynk.ffi.new("char[%s]" % string_length) for i in xrange(num_strings)]
+        keepalive = [pynk.ffi.new("char[%s]" % string_length) for i in range(num_strings)]
         self.__strings += keepalive
-        self.declare(name, keepalive, "char*[]")
+        self.declare(name, keepalive, "char*[]".encode('utf-8'))
 
     def tree_push(self, ctx, tree_type, title, state, unique_id_str):
         """ The 'nk_tree_push' macro generates a unique ID for your tree based on the
@@ -114,11 +114,11 @@ class Overview(object):
         callerframerecord = inspect.stack()[1]
         frame = callerframerecord[0]
         info = inspect.getframeinfo(frame)
-        return pynk.lib.nk_tree_push_hashed(ctx, tree_type, title, state, info.filename, len(info.filename), info.lineno)
+        return pynk.lib.nk_tree_push_hashed(ctx, tree_type, title, state, info.filename.encode('utf-8'), len(info.filename), info.lineno)
 
     def get_field_cdata(self, cdata, name_str):
         """ Make it easy to get the address of a field in a deeply nested struct. """
-        names = name_str.split(".")
+        names = name_str.split(".".encode('utf-8'))
         for name in names:
             cdata = pynk.ffi.addressof(cdata, name)
         return cdata
@@ -144,23 +144,23 @@ class Overview(object):
         # static int scale_left = nk_false;
         # static nk_flags window_flags = 0;
         # static int minimizable = nk_true;
-        self.declare("show_menu", 1, "int*")
-        self.declare("titlebar", 1, "int*")
-        self.declare("border", 1, "int*")
-        self.declare("resize", 1, "int*")
-        self.declare("movable", 1, "int*")
-        self.declare("no_scrollbar", 0, "int*")
-        self.declare("scale_left", 0, "int*")
-        self.declare("window_flags", 0, "int*")
-        self.declare("minimizable", 1, "int*")
+        self.declare("show_menu".encode('utf-8'), 1, "int*".encode('utf-8'))
+        self.declare("titlebar".encode('utf-8'), 1, "int*".encode('utf-8'))
+        self.declare("border".encode('utf-8'), 1, "int*".encode('utf-8'))
+        self.declare("resize".encode('utf-8'), 1, "int*".encode('utf-8'))
+        self.declare("movable".encode('utf-8'), 1, "int*".encode('utf-8'))
+        self.declare("no_scrollbar".encode('utf-8'), 0, "int*".encode('utf-8'))
+        self.declare("scale_left".encode('utf-8'), 0, "int*".encode('utf-8'))
+        self.declare("window_flags".encode('utf-8'), 0, "int*".encode('utf-8'))
+        self.declare("minimizable".encode('utf-8'), 1, "int*".encode('utf-8'))
 
 
         #
         # /* popups */
         # static enum nk_style_header_align header_align = NK_HEADER_RIGHT;
         # static int show_app_about = nk_false;
-        self.declare("header_align", pynk.lib.NK_HEADER_RIGHT)
-        self.declare("show_app_about", False)
+        self.declare("header_align".encode('utf-8'), pynk.lib.NK_HEADER_RIGHT)
+        self.declare("show_app_about".encode('utf-8'), False)
 
         #
         # /* window flags */
@@ -182,9 +182,9 @@ class Overview(object):
         if self.minimizable[0]: self.window_flags[0] |= pynk.lib.NK_WINDOW_MINIMIZABLE
 
         #
-        # if (nk_begin(ctx, "Overview", nk_rect(10, 10, 400, 600), window_flags))
+        # if (nk_begin(ctx, "Overview".encode('utf-8'), nk_rect(10, 10, 400, 600), window_flags))
         # {
-        if pynk.lib.nk_begin(ctx, "PyOverview", pynk.lib.nk_rect(10, 10, 400, 600), self.window_flags[0]):
+        if pynk.lib.nk_begin(ctx, "PyOverview".encode('utf-8'), pynk.lib.nk_rect(10, 10, 400, 600), self.window_flags[0]):
             # if (show_menu)
             # {
             if self.show_menu:
@@ -196,52 +196,52 @@ class Overview(object):
                 # nk_menubar_begin(ctx);
                 MENU_DEFAULT = 0
                 MENU_WINDOWS = 1
-                self.declare("mprog", 60, "nk_size*")
-                self.declare("mslider", 10, "int*")
-                self.declare("mcheck", 0, "int*")
+                self.declare("mprog".encode('utf-8'), 60, "nk_size*".encode('utf-8'))
+                self.declare("mslider".encode('utf-8'), 10, "int*".encode('utf-8'))
+                self.declare("mcheck".encode('utf-8'), 0, "int*".encode('utf-8'))
                 pynk.lib.nk_menubar_begin(ctx)
 
                 #
                 # /* menu #1 */
                 # nk_layout_row_begin(ctx, NK_STATIC, 25, 5);
                 # nk_layout_row_push(ctx, 45);
-                # if (nk_menu_begin_label(ctx, "MENU", NK_TEXT_LEFT, nk_vec2(120, 200)))
+                # if (nk_menu_begin_label(ctx, "MENU".encode('utf-8'), NK_TEXT_LEFT, nk_vec2(120, 200)))
                 # {
                 pynk.lib.nk_layout_row_begin(ctx, pynk.lib.NK_STATIC, 25, 5)
                 pynk.lib.nk_layout_row_push(ctx, 45)
-                if pynk.lib.nk_menu_begin_label(ctx, "MENU", pynk.lib.NK_TEXT_LEFT, pynk.lib.nk_vec2(120, 200)):
+                if pynk.lib.nk_menu_begin_label(ctx, "MENU".encode('utf-8'), pynk.lib.NK_TEXT_LEFT, pynk.lib.nk_vec2(120, 200)):
                     # static size_t prog = 40;
                     # static int slider = 10;
                     # static int check = nk_true;
                     # nk_layout_row_dynamic(ctx, 25, 1);
-                    # if (nk_menu_item_label(ctx, "Hide", NK_TEXT_LEFT))
+                    # if (nk_menu_item_label(ctx, "Hide".encode('utf-8'), NK_TEXT_LEFT))
                     #     show_menu = nk_false;
-                    # if (nk_menu_item_label(ctx, "About", NK_TEXT_LEFT))
+                    # if (nk_menu_item_label(ctx, "About".encode('utf-8'), NK_TEXT_LEFT))
                     #     show_app_about = nk_true;
                     # nk_progress(ctx, &prog, 100, NK_MODIFIABLE);
                     # nk_slider_int(ctx, 0, &slider, 16, 1);
-                    # nk_checkbox_label(ctx, "check", &check);
+                    # nk_checkbox_label(ctx, "check".encode('utf-8'), &check);
                     # nk_menu_end(ctx);
-                    self.declare("prog", 40, "unsigned int*")
-                    self.declare("slider", 10, "int*")
-                    self.declare("check", 1, "int*")
+                    self.declare("prog".encode('utf-8'), 40, "unsigned int*".encode('utf-8'))
+                    self.declare("slider".encode('utf-8'), 10, "int*".encode('utf-8'))
+                    self.declare("check".encode('utf-8'), 1, "int*".encode('utf-8'))
                     pynk.lib.nk_layout_row_dynamic(ctx, 25, 1)
-                    if pynk.lib.nk_menu_item_label(ctx, "Hide", pynk.lib.NK_TEXT_LEFT):
+                    if pynk.lib.nk_menu_item_label(ctx, "Hide".encode('utf-8'), pynk.lib.NK_TEXT_LEFT):
                         self.show_menu = False;
-                    if pynk.lib.nk_menu_item_label(ctx, "About", pynk.lib.NK_TEXT_LEFT):
+                    if pynk.lib.nk_menu_item_label(ctx, "About".encode('utf-8'), pynk.lib.NK_TEXT_LEFT):
                         self.show_app_about = True;
                     pynk.lib.nk_progress(ctx, self.prog, 100, pynk.lib.NK_MODIFIABLE)
                     pynk.lib.nk_slider_int(ctx, 0, self.slider, 16, 1)
-                    pynk.lib.nk_checkbox_label(ctx, "check", self.check);
+                    pynk.lib.nk_checkbox_label(ctx, "check".encode('utf-8'), self.check);
                     pynk.lib.nk_menu_end(ctx);
 
                 # }
                 # /* menu #2 */
                 # nk_layout_row_push(ctx, 60);
-                # if (nk_menu_begin_label(ctx, "ADVANCED", NK_TEXT_LEFT, nk_vec2(200, 600)))
+                # if (nk_menu_begin_label(ctx, "ADVANCED".encode('utf-8'), NK_TEXT_LEFT, nk_vec2(200, 600)))
                 # {
                 pynk.lib.nk_layout_row_push(ctx, 60);
-                if pynk.lib.nk_menu_begin_label(ctx, "ADVANCED", pynk.lib.NK_TEXT_LEFT, pynk.lib.nk_vec2(200, 600)):
+                if pynk.lib.nk_menu_begin_label(ctx, "ADVANCED".encode('utf-8'), pynk.lib.NK_TEXT_LEFT, pynk.lib.nk_vec2(200, 600)):
                     # enum menu_state {MENU_NONE,MENU_FILE, MENU_EDIT,MENU_VIEW,MENU_CHART};
                     # static enum menu_state menu_state = MENU_NONE;
                     # enum nk_collapse_states state;
@@ -250,74 +250,74 @@ class Overview(object):
                     MENU_EDIT = 2
                     MENU_VIEW = 3
                     MENU_CHART = 4
-                    self.declare("menu_state", MENU_NONE)
+                    self.declare("menu_state".encode('utf-8'), MENU_NONE)
                     state = pynk.ffi.new("enum nk_collapse_states*")
 
                     # state = (menu_state == MENU_FILE) ? NK_MAXIMIZED: NK_MINIMIZED;
-                    # if (nk_tree_state_push(ctx, NK_TREE_TAB, "FILE", &state)) {
+                    # if (nk_tree_state_push(ctx, NK_TREE_TAB, "FILE".encode('utf-8'), &state)) {
                     #     menu_state = MENU_FILE;
-                    #     nk_menu_item_label(ctx, "New", NK_TEXT_LEFT);
-                    #     nk_menu_item_label(ctx, "Open", NK_TEXT_LEFT);
-                    #     nk_menu_item_label(ctx, "Save", NK_TEXT_LEFT);
-                    #     nk_menu_item_label(ctx, "Close", NK_TEXT_LEFT);
-                    #     nk_menu_item_label(ctx, "Exit", NK_TEXT_LEFT);
+                    #     nk_menu_item_label(ctx, "New".encode('utf-8'), NK_TEXT_LEFT);
+                    #     nk_menu_item_label(ctx, "Open".encode('utf-8'), NK_TEXT_LEFT);
+                    #     nk_menu_item_label(ctx, "Save".encode('utf-8'), NK_TEXT_LEFT);
+                    #     nk_menu_item_label(ctx, "Close".encode('utf-8'), NK_TEXT_LEFT);
+                    #     nk_menu_item_label(ctx, "Exit".encode('utf-8'), NK_TEXT_LEFT);
                     #     nk_tree_pop(ctx);
                     # } else menu_state = (menu_state == MENU_FILE) ? MENU_NONE: menu_state;
                     state[0] = pynk.lib.NK_MAXIMIZED if self.menu_state == MENU_FILE else pynk.lib.NK_MINIMIZED
-                    if pynk.lib.nk_tree_state_push(ctx, pynk.lib.NK_TREE_TAB, "FILE", state):
+                    if pynk.lib.nk_tree_state_push(ctx, pynk.lib.NK_TREE_TAB, "FILE".encode('utf-8'), state):
                         self.menu_state = MENU_FILE
-                        pynk.lib.nk_menu_item_label(ctx, "New", pynk.lib.NK_TEXT_LEFT)
-                        pynk.lib.nk_menu_item_label(ctx, "Open", pynk.lib.NK_TEXT_LEFT)
-                        pynk.lib.nk_menu_item_label(ctx, "Save", pynk.lib.NK_TEXT_LEFT)
-                        pynk.lib.nk_menu_item_label(ctx, "Close", pynk.lib.NK_TEXT_LEFT)
-                        pynk.lib.nk_menu_item_label(ctx, "Exit", pynk.lib.NK_TEXT_LEFT)
+                        pynk.lib.nk_menu_item_label(ctx, "New".encode('utf-8'), pynk.lib.NK_TEXT_LEFT)
+                        pynk.lib.nk_menu_item_label(ctx, "Open".encode('utf-8'), pynk.lib.NK_TEXT_LEFT)
+                        pynk.lib.nk_menu_item_label(ctx, "Save".encode('utf-8'), pynk.lib.NK_TEXT_LEFT)
+                        pynk.lib.nk_menu_item_label(ctx, "Close".encode('utf-8'), pynk.lib.NK_TEXT_LEFT)
+                        pynk.lib.nk_menu_item_label(ctx, "Exit".encode('utf-8'), pynk.lib.NK_TEXT_LEFT)
                         pynk.lib.nk_tree_pop(ctx)
                     elif self.menu_state == MENU_FILE:
                         self.menu_state = MENU_NONE
 
                     #
                     # state = (menu_state == MENU_EDIT) ? NK_MAXIMIZED: NK_MINIMIZED;
-                    # if (nk_tree_state_push(ctx, NK_TREE_TAB, "EDIT", &state)) {
+                    # if (nk_tree_state_push(ctx, NK_TREE_TAB, "EDIT".encode('utf-8'), &state)) {
                     #     menu_state = MENU_EDIT;
-                    #     nk_menu_item_label(ctx, "Copy", NK_TEXT_LEFT);
-                    #     nk_menu_item_label(ctx, "Delete", NK_TEXT_LEFT);
-                    #     nk_menu_item_label(ctx, "Cut", NK_TEXT_LEFT);
-                    #     nk_menu_item_label(ctx, "Paste", NK_TEXT_LEFT);
+                    #     nk_menu_item_label(ctx, "Copy".encode('utf-8'), NK_TEXT_LEFT);
+                    #     nk_menu_item_label(ctx, "Delete".encode('utf-8'), NK_TEXT_LEFT);
+                    #     nk_menu_item_label(ctx, "Cut".encode('utf-8'), NK_TEXT_LEFT);
+                    #     nk_menu_item_label(ctx, "Paste".encode('utf-8'), NK_TEXT_LEFT);
                     #     nk_tree_pop(ctx);
                     # } else menu_state = (menu_state == MENU_EDIT) ? MENU_NONE: menu_state;
                     state[0] = pynk.lib.NK_MAXIMIZED if self.menu_state == MENU_EDIT else pynk.lib.NK_MINIMIZED
-                    if pynk.lib.nk_tree_state_push(ctx, pynk.lib.NK_TREE_TAB, "EDIT", state):
+                    if pynk.lib.nk_tree_state_push(ctx, pynk.lib.NK_TREE_TAB, "EDIT".encode('utf-8'), state):
                         self.menu_state = MENU_EDIT
-                        pynk.lib.nk_menu_item_label(ctx, "Copy", pynk.lib.NK_TEXT_LEFT)
-                        pynk.lib.nk_menu_item_label(ctx, "Delete", pynk.lib.NK_TEXT_LEFT)
-                        pynk.lib.nk_menu_item_label(ctx, "Cut", pynk.lib.NK_TEXT_LEFT)
-                        pynk.lib.nk_menu_item_label(ctx, "Paste", pynk.lib.NK_TEXT_LEFT)
+                        pynk.lib.nk_menu_item_label(ctx, "Copy".encode('utf-8'), pynk.lib.NK_TEXT_LEFT)
+                        pynk.lib.nk_menu_item_label(ctx, "Delete".encode('utf-8'), pynk.lib.NK_TEXT_LEFT)
+                        pynk.lib.nk_menu_item_label(ctx, "Cut".encode('utf-8'), pynk.lib.NK_TEXT_LEFT)
+                        pynk.lib.nk_menu_item_label(ctx, "Paste".encode('utf-8'), pynk.lib.NK_TEXT_LEFT)
                         pynk.lib.nk_tree_pop(ctx)
                     elif self.menu_state == MENU_EDIT:
                         self.menu_state = MENU_NONE
 
                     #
                     # state = (menu_state == MENU_VIEW) ? NK_MAXIMIZED: NK_MINIMIZED;
-                    # if (nk_tree_state_push(ctx, NK_TREE_TAB, "VIEW", &state)) {
+                    # if (nk_tree_state_push(ctx, NK_TREE_TAB, "VIEW".encode('utf-8'), &state)) {
                     #     menu_state = MENU_VIEW;
-                    #     nk_menu_item_label(ctx, "About", NK_TEXT_LEFT);
-                    #     nk_menu_item_label(ctx, "Options", NK_TEXT_LEFT);
-                    #     nk_menu_item_label(ctx, "Customize", NK_TEXT_LEFT);
+                    #     nk_menu_item_label(ctx, "About".encode('utf-8'), NK_TEXT_LEFT);
+                    #     nk_menu_item_label(ctx, "Options".encode('utf-8'), NK_TEXT_LEFT);
+                    #     nk_menu_item_label(ctx, "Customize".encode('utf-8'), NK_TEXT_LEFT);
                     #     nk_tree_pop(ctx);
                     # } else menu_state = (menu_state == MENU_VIEW) ? MENU_NONE: menu_state;
                     state[0] = pynk.lib.NK_MAXIMIZED if self.menu_state == MENU_VIEW else pynk.lib.NK_MINIMIZED
-                    if pynk.lib.nk_tree_state_push(ctx, pynk.lib.NK_TREE_TAB, "VIEW", state):
+                    if pynk.lib.nk_tree_state_push(ctx, pynk.lib.NK_TREE_TAB, "VIEW".encode('utf-8'), state):
                         self.menu_state = MENU_VIEW
-                        pynk.lib.nk_menu_item_label(ctx, "About", pynk.lib.NK_TEXT_LEFT)
-                        pynk.lib.nk_menu_item_label(ctx, "Options", pynk.lib.NK_TEXT_LEFT)
-                        pynk.lib.nk_menu_item_label(ctx, "Customize", pynk.lib.NK_TEXT_LEFT)
+                        pynk.lib.nk_menu_item_label(ctx, "About".encode('utf-8'), pynk.lib.NK_TEXT_LEFT)
+                        pynk.lib.nk_menu_item_label(ctx, "Options".encode('utf-8'), pynk.lib.NK_TEXT_LEFT)
+                        pynk.lib.nk_menu_item_label(ctx, "Customize".encode('utf-8'), pynk.lib.NK_TEXT_LEFT)
                         pynk.lib.nk_tree_pop(ctx)
                     elif self.menu_state == MENU_VIEW:
                         self.menu_state = MENU_NONE
 
                     #
                     # state = (menu_state == MENU_CHART) ? NK_MAXIMIZED: NK_MINIMIZED;
-                    # if (nk_tree_state_push(ctx, NK_TREE_TAB, "CHART", &state)) {
+                    # if (nk_tree_state_push(ctx, NK_TREE_TAB, "CHART".encode('utf-8'), &state)) {
                     #     size_t i = 0;
                     #     const float values[]={26.0f,13.0f,30.0f,15.0f,25.0f,10.0f,20.0f,40.0f,12.0f,8.0f,22.0f,28.0f};
                     #     menu_state = MENU_CHART;
@@ -330,7 +330,7 @@ class Overview(object):
                     # } else menu_state = (menu_state == MENU_CHART) ? MENU_NONE: menu_state;
                     # nk_menu_end(ctx);
                     state[0] = pynk.lib.NK_MAXIMIZED if self.menu_state == MENU_CHART else pynk.lib.NK_MINIMIZED
-                    if pynk.lib.nk_tree_state_push(ctx, pynk.lib.NK_TREE_TAB, "CHART", state):
+                    if pynk.lib.nk_tree_state_push(ctx, pynk.lib.NK_TREE_TAB, "CHART".encode('utf-8'), state):
                         self.menu_state = MENU_CHART
                         # size_t i = 0;
                         # const float values[]={26.0f,13.0f,30.0f,15.0f,25.0f,10.0f,20.0f,40.0f,12.0f,8.0f,22.0f,28.0f};
@@ -354,12 +354,12 @@ class Overview(object):
                 # nk_layout_row_push(ctx, 70);
                 # nk_progress(ctx, &mprog, 100, NK_MODIFIABLE);
                 # nk_slider_int(ctx, 0, &mslider, 16, 1);
-                # nk_checkbox_label(ctx, "check", &mcheck);
+                # nk_checkbox_label(ctx, "check".encode('utf-8'), &mcheck);
                 # nk_menubar_end(ctx);
                 pynk.lib.nk_layout_row_push(ctx, 70)
                 pynk.lib.nk_progress(ctx, self.mprog, 100, pynk.lib.NK_MODIFIABLE)
                 pynk.lib.nk_slider_int(ctx, 0, self.mslider, 16, 1)
-                pynk.lib.nk_checkbox_label(ctx, "check", self.mcheck)
+                pynk.lib.nk_checkbox_label(ctx, "check".encode('utf-8'), self.mcheck)
                 pynk.lib.nk_menubar_end(ctx);
             # }
             #
@@ -368,100 +368,100 @@ class Overview(object):
             if self.show_app_about:
                 # /* about popup */
                 # static struct nk_rect s = {20, 100, 300, 190};
-                # if (nk_popup_begin(ctx, NK_POPUP_STATIC, "About", NK_WINDOW_CLOSABLE, s))
+                # if (nk_popup_begin(ctx, NK_POPUP_STATIC, "About".encode('utf-8'), NK_WINDOW_CLOSABLE, s))
                 # {
                 #     nk_layout_row_dynamic(ctx, 20, 1);
-                #     nk_label(ctx, "Nuklear", NK_TEXT_LEFT);
-                #     nk_label(ctx, "By Micha Mettke", NK_TEXT_LEFT);
-                #     nk_label(ctx, "nuklear is licensed under the public domain License.",  NK_TEXT_LEFT);
+                #     nk_label(ctx, "Nuklear".encode('utf-8'), NK_TEXT_LEFT);
+                #     nk_label(ctx, "By Micha Mettke".encode('utf-8'), NK_TEXT_LEFT);
+                #     nk_label(ctx, "nuklear is licensed under the public domain License.".encode('utf-8'),  NK_TEXT_LEFT);
                 #     nk_popup_end(ctx);
                 # } else show_app_about = nk_false;
-                if pynk.lib.nk_popup_begin(ctx, pynk.lib.NK_POPUP_STATIC, "About", pynk.lib.NK_WINDOW_CLOSABLE, pynk.lib.nk_rect(20, 100, 300, 190)):
+                if pynk.lib.nk_popup_begin(ctx, pynk.lib.NK_POPUP_STATIC, "About".encode('utf-8'), pynk.lib.NK_WINDOW_CLOSABLE, pynk.lib.nk_rect(20, 100, 300, 190)):
                     pynk.lib.nk_layout_row_dynamic(ctx, 20, 1);
-                    pynk.lib.nk_label(ctx, "Nuklear", pynk.lib.NK_TEXT_LEFT);
-                    pynk.lib.nk_label(ctx, "By Micha Mettke", pynk.lib.NK_TEXT_LEFT);
-                    pynk.lib.nk_label(ctx, "nuklear is licensed under the public domain License.",  pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_label(ctx, "Nuklear".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_label(ctx, "By Micha Mettke".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_label(ctx, "nuklear is licensed under the public domain License.".encode('utf-8'),  pynk.lib.NK_TEXT_LEFT);
                     pynk.lib.nk_popup_end(ctx);
                 else: self.show_app_about = False;
             # }
             #
             # /* window flags */
-            # if (nk_tree_push(ctx, NK_TREE_TAB, "Window", NK_MINIMIZED)) {
+            # if (nk_tree_push(ctx, NK_TREE_TAB, "Window".encode('utf-8'), NK_MINIMIZED)) {
             #     nk_layout_row_dynamic(ctx, 30, 2);
-            #     nk_checkbox_label(ctx, "Titlebar", &titlebar);
-            #     nk_checkbox_label(ctx, "Menu", &show_menu);
-            #     nk_checkbox_label(ctx, "Border", &border);
-            #     nk_checkbox_label(ctx, "Resizable", &resize);
-            #     nk_checkbox_label(ctx, "Movable", &movable);
-            #     nk_checkbox_label(ctx, "No Scrollbar", &no_scrollbar);
-            #     nk_checkbox_label(ctx, "Minimizable", &minimizable);
-            #     nk_checkbox_label(ctx, "Scale Left", &scale_left);
+            #     nk_checkbox_label(ctx, "Titlebar".encode('utf-8'), &titlebar);
+            #     nk_checkbox_label(ctx, "Menu".encode('utf-8'), &show_menu);
+            #     nk_checkbox_label(ctx, "Border".encode('utf-8'), &border);
+            #     nk_checkbox_label(ctx, "Resizable".encode('utf-8'), &resize);
+            #     nk_checkbox_label(ctx, "Movable".encode('utf-8'), &movable);
+            #     nk_checkbox_label(ctx, "No Scrollbar".encode('utf-8'), &no_scrollbar);
+            #     nk_checkbox_label(ctx, "Minimizable".encode('utf-8'), &minimizable);
+            #     nk_checkbox_label(ctx, "Scale Left".encode('utf-8'), &scale_left);
             #     nk_tree_pop(ctx);
             # }
-            if self.tree_push(ctx, pynk.lib.NK_TREE_TAB, "Window", pynk.lib.NK_MINIMIZED, "1"):
+            if self.tree_push(ctx, pynk.lib.NK_TREE_TAB, "Window".encode('utf-8'), pynk.lib.NK_MINIMIZED, "1".encode('utf-8')):
                 pynk.lib.nk_layout_row_dynamic(ctx, 30, 2);
-                pynk.lib.nk_checkbox_label(ctx, "Titlebar", self.titlebar);
-                pynk.lib.nk_checkbox_label(ctx, "Menu", self.show_menu);
-                pynk.lib.nk_checkbox_label(ctx, "Border", self.border);
-                pynk.lib.nk_checkbox_label(ctx, "Resizable", self.resize);
-                pynk.lib.nk_checkbox_label(ctx, "Movable", self.movable);
-                pynk.lib.nk_checkbox_label(ctx, "No Scrollbar", self.no_scrollbar);
-                pynk.lib.nk_checkbox_label(ctx, "Minimizable", self.minimizable);
-                pynk.lib.nk_checkbox_label(ctx, "Scale Left", self.scale_left);
+                pynk.lib.nk_checkbox_label(ctx, "Titlebar".encode('utf-8'), self.titlebar);
+                pynk.lib.nk_checkbox_label(ctx, "Menu".encode('utf-8'), self.show_menu);
+                pynk.lib.nk_checkbox_label(ctx, "Border".encode('utf-8'), self.border);
+                pynk.lib.nk_checkbox_label(ctx, "Resizable".encode('utf-8'), self.resize);
+                pynk.lib.nk_checkbox_label(ctx, "Movable".encode('utf-8'), self.movable);
+                pynk.lib.nk_checkbox_label(ctx, "No Scrollbar".encode('utf-8'), self.no_scrollbar);
+                pynk.lib.nk_checkbox_label(ctx, "Minimizable".encode('utf-8'), self.minimizable);
+                pynk.lib.nk_checkbox_label(ctx, "Scale Left".encode('utf-8'), self.scale_left);
                 pynk.lib.nk_tree_pop(ctx);
 
             #
-            # if (nk_tree_push(ctx, NK_TREE_TAB, "Widgets", NK_MINIMIZED))
+            # if (nk_tree_push(ctx, NK_TREE_TAB, "Widgets".encode('utf-8'), NK_MINIMIZED))
             # {
             #     enum options {A,B,C};
             #     static int checkbox;
             #     static int option;
-            if self.tree_push(ctx, pynk.lib.NK_TREE_TAB, "Widgets", pynk.lib.NK_MINIMIZED, "2"):
+            if self.tree_push(ctx, pynk.lib.NK_TREE_TAB, "Widgets".encode('utf-8'), pynk.lib.NK_MINIMIZED, "2".encode('utf-8')):
                 A = 0
                 B = 1
                 C = 2
-                self.declare("checkbox", 0, "int*")
-                self.declare("option", 0, "int*")
+                self.declare("checkbox".encode('utf-8'), 0, "int*".encode('utf-8'))
+                self.declare("option".encode('utf-8'), 0, "int*".encode('utf-8'))
 
-                # if (nk_tree_push(ctx, NK_TREE_NODE, "Text", NK_MINIMIZED))
+                # if (nk_tree_push(ctx, NK_TREE_NODE, "Text".encode('utf-8'), NK_MINIMIZED))
                 # {
                 #     /* Text Widgets */
                 #     nk_layout_row_dynamic(ctx, 20, 1);
-                #     nk_label(ctx, "Label aligned left", NK_TEXT_LEFT);
-                #     nk_label(ctx, "Label aligned centered", NK_TEXT_CENTERED);
-                #     nk_label(ctx, "Label aligned right", NK_TEXT_RIGHT);
-                #     nk_label_colored(ctx, "Blue text", NK_TEXT_LEFT, nk_rgb(0,0,255));
-                #     nk_label_colored(ctx, "Yellow text", NK_TEXT_LEFT, nk_rgb(255,255,0));
-                #     nk_text(ctx, "Text without /0", 15, NK_TEXT_RIGHT);
+                #     nk_label(ctx, "Label aligned left".encode('utf-8'), NK_TEXT_LEFT);
+                #     nk_label(ctx, "Label aligned centered".encode('utf-8'), NK_TEXT_CENTERED);
+                #     nk_label(ctx, "Label aligned right".encode('utf-8'), NK_TEXT_RIGHT);
+                #     nk_label_colored(ctx, "Blue text".encode('utf-8'), NK_TEXT_LEFT, nk_rgb(0,0,255));
+                #     nk_label_colored(ctx, "Yellow text".encode('utf-8'), NK_TEXT_LEFT, nk_rgb(255,255,0));
+                #     nk_text(ctx, "Text without /0".encode('utf-8'), 15, NK_TEXT_RIGHT);
                 #
                 #     nk_layout_row_static(ctx, 100, 200, 1);
-                #     nk_label_wrap(ctx, "This is a very long line to hopefully get this text to be wrapped into multiple lines to show line wrapping");
+                #     nk_label_wrap(ctx, "This is a very long line to hopefully get this text to be wrapped into multiple lines to show line wrapping".encode('utf-8'));
                 #     nk_layout_row_dynamic(ctx, 100, 1);
-                #     nk_label_wrap(ctx, "This is another long text to show dynamic window changes on multiline text");
+                #     nk_label_wrap(ctx, "This is another long text to show dynamic window changes on multiline text".encode('utf-8'));
                 #     nk_tree_pop(ctx);
                 # }
-                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Text", pynk.lib.NK_MINIMIZED, "3"):
+                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Text".encode('utf-8'), pynk.lib.NK_MINIMIZED, "3".encode('utf-8')):
                     pynk.lib.nk_layout_row_dynamic(ctx, 20, 1);
-                    pynk.lib.nk_label(ctx, "Label aligned left", pynk.lib.NK_TEXT_LEFT);
-                    pynk.lib.nk_label(ctx, "Label aligned centered", pynk.lib.NK_TEXT_CENTERED);
-                    pynk.lib.nk_label(ctx, "Label aligned right", pynk.lib.NK_TEXT_RIGHT);
-                    pynk.lib.nk_label_colored(ctx, "Blue text", pynk.lib.NK_TEXT_LEFT, pynk.lib.nk_rgb(0,0,255));
-                    pynk.lib.nk_label_colored(ctx, "Yellow text", pynk.lib.NK_TEXT_LEFT, pynk.lib.nk_rgb(255,255,0));
-                    pynk.lib.nk_text(ctx, "Text without /0", 15, pynk.lib.NK_TEXT_RIGHT);
+                    pynk.lib.nk_label(ctx, "Label aligned left".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_label(ctx, "Label aligned centered".encode('utf-8'), pynk.lib.NK_TEXT_CENTERED);
+                    pynk.lib.nk_label(ctx, "Label aligned right".encode('utf-8'), pynk.lib.NK_TEXT_RIGHT);
+                    pynk.lib.nk_label_colored(ctx, "Blue text".encode('utf-8'), pynk.lib.NK_TEXT_LEFT, pynk.lib.nk_rgb(0,0,255));
+                    pynk.lib.nk_label_colored(ctx, "Yellow text".encode('utf-8'), pynk.lib.NK_TEXT_LEFT, pynk.lib.nk_rgb(255,255,0));
+                    pynk.lib.nk_text(ctx, "Text without /0".encode('utf-8'), 15, pynk.lib.NK_TEXT_RIGHT);
                     pynk.lib.nk_layout_row_static(ctx, 100, 200, 1);
-                    pynk.lib.nk_label_wrap(ctx, "This is a very long line to hopefully get this text to be wrapped into multiple lines to show line wrapping");
+                    pynk.lib.nk_label_wrap(ctx, "This is a very long line to hopefully get this text to be wrapped into multiple lines to show line wrapping".encode('utf-8'));
                     pynk.lib.nk_layout_row_dynamic(ctx, 100, 1);
-                    pynk.lib.nk_label_wrap(ctx, "This is another long text to show dynamic window changes on multiline text");
+                    pynk.lib.nk_label_wrap(ctx, "This is another long text to show dynamic window changes on multiline text".encode('utf-8'));
                     pynk.lib.nk_tree_pop(ctx);
                 #
-                # if (nk_tree_push(ctx, NK_TREE_NODE, "Button", NK_MINIMIZED))
+                # if (nk_tree_push(ctx, NK_TREE_NODE, "Button".encode('utf-8'), NK_MINIMIZED))
                 # {
                 #     /* Buttons Widgets */
                 #     nk_layout_row_static(ctx, 30, 100, 3);
-                #     if (nk_button_label(ctx, "Button"))
+                #     if (nk_button_label(ctx, "Button".encode('utf-8')))
                 #         fprintf(stdout, "Button pressed!\n");
                 #     nk_button_set_behavior(ctx, NK_BUTTON_REPEATER);
-                #     if (nk_button_label(ctx, "Repeater"))
+                #     if (nk_button_label(ctx, "Repeater".encode('utf-8')))
                 #         fprintf(stdout, "Repeater is being pressed!\n");
                 #     nk_button_set_behavior(ctx, NK_BUTTON_DEFAULT);
                 #     nk_button_color(ctx, nk_rgb(0,0,255));
@@ -477,17 +477,17 @@ class Overview(object):
                 #     nk_button_symbol(ctx, NK_SYMBOL_TRIANGLE_RIGHT);
                 #
                 #     nk_layout_row_static(ctx, 30, 100, 2);
-                #     nk_button_symbol_label(ctx, NK_SYMBOL_TRIANGLE_LEFT, "prev", NK_TEXT_RIGHT);
-                #     nk_button_symbol_label(ctx, NK_SYMBOL_TRIANGLE_RIGHT, "next", NK_TEXT_LEFT);
+                #     nk_button_symbol_label(ctx, NK_SYMBOL_TRIANGLE_LEFT, "prev".encode('utf-8'), NK_TEXT_RIGHT);
+                #     nk_button_symbol_label(ctx, NK_SYMBOL_TRIANGLE_RIGHT, "next".encode('utf-8'), NK_TEXT_LEFT);
                 #     nk_tree_pop(ctx);
                 # }
-                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Button", pynk.lib.NK_MINIMIZED, "4"):
+                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Button".encode('utf-8'), pynk.lib.NK_MINIMIZED, "4".encode('utf-8')):
                     pynk.lib.nk_layout_row_static(ctx, 30, 100, 3);
-                    if pynk.lib.nk_button_label(ctx, "Button"):
-                        print "Button pressed!"
+                    if pynk.lib.nk_button_label(ctx, "Button".encode('utf-8')):
+                        print("Button pressed!".encode('utf-8'))
                     pynk.lib.nk_button_set_behavior(ctx, pynk.lib.NK_BUTTON_REPEATER);
-                    if pynk.lib.nk_button_label(ctx, "Repeater"):
-                        print "Repeater is being pressed!"
+                    if pynk.lib.nk_button_label(ctx, "Repeater".encode('utf-8')):
+                        print("Repeater is being pressed!".encode('utf-8'))
                     pynk.lib.nk_button_set_behavior(ctx, pynk.lib.NK_BUTTON_DEFAULT);
                     pynk.lib.nk_button_color(ctx, pynk.lib.nk_rgb(0,0,255));
                     pynk.lib.nk_layout_row_static(ctx, 25, 25, 8);
@@ -500,11 +500,11 @@ class Overview(object):
                     pynk.lib.nk_button_symbol(ctx, pynk.lib.NK_SYMBOL_TRIANGLE_LEFT);
                     pynk.lib.nk_button_symbol(ctx, pynk.lib.NK_SYMBOL_TRIANGLE_RIGHT);
                     pynk.lib.nk_layout_row_static(ctx, 30, 100, 2);
-                    pynk.lib.nk_button_symbol_label(ctx, pynk.lib.NK_SYMBOL_TRIANGLE_LEFT, "prev", pynk.lib.NK_TEXT_RIGHT);
-                    pynk.lib.nk_button_symbol_label(ctx, pynk.lib.NK_SYMBOL_TRIANGLE_RIGHT, "next", pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_button_symbol_label(ctx, pynk.lib.NK_SYMBOL_TRIANGLE_LEFT, "prev".encode('utf-8'), pynk.lib.NK_TEXT_RIGHT);
+                    pynk.lib.nk_button_symbol_label(ctx, pynk.lib.NK_SYMBOL_TRIANGLE_RIGHT, "next".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                     pynk.lib.nk_tree_pop(ctx);
                 #
-                # if (nk_tree_push(ctx, NK_TREE_NODE, "Basic", NK_MINIMIZED))
+                # if (nk_tree_push(ctx, NK_TREE_NODE, "Basic".encode('utf-8'), NK_MINIMIZED))
                 # {
                 #     /* Basic widgets */
                 #     static int int_slider = 5;
@@ -523,120 +523,120 @@ class Overview(object):
                 #     static const float ratio[] = {120, 150};
                 #
                 #     nk_layout_row_static(ctx, 30, 100, 1);
-                #     nk_checkbox_label(ctx, "Checkbox", &checkbox);
+                #     nk_checkbox_label(ctx, "Checkbox".encode('utf-8'), &checkbox);
                 #
                 #     nk_layout_row_static(ctx, 30, 80, 3);
-                #     option = nk_option_label(ctx, "optionA", option == A) ? A : option;
-                #     option = nk_option_label(ctx, "optionB", option == B) ? B : option;
-                #     option = nk_option_label(ctx, "optionC", option == C) ? C : option;
+                #     option = nk_option_label(ctx, "optionA".encode('utf-8'), option == A) ? A : option;
+                #     option = nk_option_label(ctx, "optionB".encode('utf-8'), option == B) ? B : option;
+                #     option = nk_option_label(ctx, "optionC".encode('utf-8'), option == C) ? C : option;
                 #
                 #
                 #     nk_layout_row(ctx, NK_STATIC, 30, 2, ratio);
-                #     nk_labelf(ctx, NK_TEXT_LEFT, "Slider int");
+                #     nk_labelf(ctx, NK_TEXT_LEFT, "Slider int".encode('utf-8'));
                 #     nk_slider_int(ctx, 0, &int_slider, 10, 1);
                 #
-                #     nk_label(ctx, "Slider float", NK_TEXT_LEFT);
+                #     nk_label(ctx, "Slider float".encode('utf-8'), NK_TEXT_LEFT);
                 #     nk_slider_float(ctx, 0, &float_slider, 5.0, 0.5f);
-                #     nk_labelf(ctx, NK_TEXT_LEFT, "Progressbar" , prog_value);
+                #     nk_labelf(ctx, NK_TEXT_LEFT, "Progressbar".encode('utf-8') , prog_value);
                 #     nk_progress(ctx, &prog_value, 100, NK_MODIFIABLE);
                 #
                 #     nk_layout_row(ctx, NK_STATIC, 25, 2, ratio);
-                #     nk_label(ctx, "Property float:", NK_TEXT_LEFT);
-                #     nk_property_float(ctx, "Float:", 0, &property_float, 64.0f, 0.1f, 0.2f);
-                #     nk_label(ctx, "Property int:", NK_TEXT_LEFT);
-                #     nk_property_int(ctx, "Int:", 0, &property_int, 100.0f, 1, 1);
-                #     nk_label(ctx, "Property neg:", NK_TEXT_LEFT);
-                #     nk_property_int(ctx, "Neg:", -10, &property_neg, 10, 1, 1);
+                #     nk_label(ctx, "Property float:".encode('utf-8'), NK_TEXT_LEFT);
+                #     nk_property_float(ctx, "Float:".encode('utf-8'), 0, &property_float, 64.0f, 0.1f, 0.2f);
+                #     nk_label(ctx, "Property int:".encode('utf-8'), NK_TEXT_LEFT);
+                #     nk_property_int(ctx, "Int:".encode('utf-8'), 0, &property_int, 100.0f, 1, 1);
+                #     nk_label(ctx, "Property neg:".encode('utf-8'), NK_TEXT_LEFT);
+                #     nk_property_int(ctx, "Neg:".encode('utf-8'), -10, &property_neg, 10, 1, 1);
                 #
                 #     nk_layout_row_dynamic(ctx, 25, 1);
-                #     nk_label(ctx, "Range:", NK_TEXT_LEFT);
+                #     nk_label(ctx, "Range:".encode('utf-8'), NK_TEXT_LEFT);
                 #     nk_layout_row_dynamic(ctx, 25, 3);
-                #     nk_property_float(ctx, "#min:", 0, &range_float_min, range_float_max, 1.0f, 0.2f);
-                #     nk_property_float(ctx, "#float:", range_float_min, &range_float_value, range_float_max, 1.0f, 0.2f);
-                #     nk_property_float(ctx, "#max:", range_float_min, &range_float_max, 100, 1.0f, 0.2f);
+                #     nk_property_float(ctx, "#min:".encode('utf-8'), 0, &range_float_min, range_float_max, 1.0f, 0.2f);
+                #     nk_property_float(ctx, "#float:".encode('utf-8'), range_float_min, &range_float_value, range_float_max, 1.0f, 0.2f);
+                #     nk_property_float(ctx, "#max:".encode('utf-8'), range_float_min, &range_float_max, 100, 1.0f, 0.2f);
                 #
-                #     nk_property_int(ctx, "#min:", INT_MIN, &range_int_min, range_int_max, 1, 10);
-                #     nk_property_int(ctx, "#neg:", range_int_min, &range_int_value, range_int_max, 1, 10);
-                #     nk_property_int(ctx, "#max:", range_int_min, &range_int_max, INT_MAX, 1, 10);
+                #     nk_property_int(ctx, "#min:".encode('utf-8'), INT_MIN, &range_int_min, range_int_max, 1, 10);
+                #     nk_property_int(ctx, "#neg:".encode('utf-8'), range_int_min, &range_int_value, range_int_max, 1, 10);
+                #     nk_property_int(ctx, "#max:".encode('utf-8'), range_int_min, &range_int_max, INT_MAX, 1, 10);
                 #
                 #     nk_tree_pop(ctx);
                 # }
-                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Basic", pynk.lib.NK_MINIMIZED, "5"):
-                    self.declare("int_slider", 5, "int*")
-                    self.declare("float_slider", 2.5, "float*")
-                    self.declare("prog_value", 40, "unsigned int*")
-                    self.declare("property_float", 2, "float*")
-                    self.declare("property_int", 10, "int*")
-                    self.declare("property_neg", 10, "int*")
-                    self.declare("range_float_min", 0, "float*")
-                    self.declare("range_float_max", 100, "float*")
-                    self.declare("range_float_value", 50, "float*")
-                    self.declare("range_int_min", 0, "int*")
-                    self.declare("range_int_value", 2048, "int*")
-                    self.declare("range_int_max", 4096, "int*")
-                    self.declare("ratio", [120, 150], "float[]")
+                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Basic".encode('utf-8'), pynk.lib.NK_MINIMIZED, "5".encode('utf-8')):
+                    self.declare("int_slider".encode('utf-8'), 5, "int*".encode('utf-8'))
+                    self.declare("float_slider".encode('utf-8'), 2.5, "float*".encode('utf-8'))
+                    self.declare("prog_value".encode('utf-8'), 40, "unsigned int*".encode('utf-8'))
+                    self.declare("property_float".encode('utf-8'), 2, "float*".encode('utf-8'))
+                    self.declare("property_int".encode('utf-8'), 10, "int*".encode('utf-8'))
+                    self.declare("property_neg".encode('utf-8'), 10, "int*".encode('utf-8'))
+                    self.declare("range_float_min".encode('utf-8'), 0, "float*".encode('utf-8'))
+                    self.declare("range_float_max".encode('utf-8'), 100, "float*".encode('utf-8'))
+                    self.declare("range_float_value".encode('utf-8'), 50, "float*".encode('utf-8'))
+                    self.declare("range_int_min".encode('utf-8'), 0, "int*".encode('utf-8'))
+                    self.declare("range_int_value".encode('utf-8'), 2048, "int*".encode('utf-8'))
+                    self.declare("range_int_max".encode('utf-8'), 4096, "int*".encode('utf-8'))
+                    self.declare("ratio".encode('utf-8'), [120, 150], "float[]".encode('utf-8'))
 
                     pynk.lib.nk_layout_row_static(ctx, 30, 100, 1)
-                    pynk.lib.nk_checkbox_label(ctx, "Checkbox", self.checkbox)
+                    pynk.lib.nk_checkbox_label(ctx, "Checkbox".encode('utf-8'), self.checkbox)
 
                     pynk.lib.nk_layout_row_static(ctx, 30, 80, 3)
-                    if pynk.lib.nk_option_label(ctx, "optionA", self.option[0] == A):
+                    if pynk.lib.nk_option_label(ctx, "optionA".encode('utf-8'), self.option[0] == A):
                         self.option[0] = A
-                    if pynk.lib.nk_option_label(ctx, "optionB", self.option[0] == B):
+                    if pynk.lib.nk_option_label(ctx, "optionB".encode('utf-8'), self.option[0] == B):
                         self.option[0] = B
-                    if pynk.lib.nk_option_label(ctx, "optionC", self.option[0] == C):
+                    if pynk.lib.nk_option_label(ctx, "optionC".encode('utf-8'), self.option[0] == C):
                         self.option[0] = C
 
                     pynk.lib.nk_layout_row(ctx, pynk.lib.NK_STATIC, 30, 2, self.ratio);
-                    pynk.lib.nk_labelf(ctx, pynk.lib.NK_TEXT_LEFT, "Slider int");
+                    pynk.lib.nk_labelf(ctx, pynk.lib.NK_TEXT_LEFT, "Slider int".encode('utf-8'));
                     pynk.lib.nk_slider_int(ctx, 0, self.int_slider, 10, 1)
 
-                    pynk.lib.nk_label(ctx, "Slider float", pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_label(ctx, "Slider float".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                     pynk.lib.nk_slider_float(ctx, 0, self.float_slider, 5.0, 0.5)
-                    pynk.lib.nk_labelf(ctx, pynk.lib.NK_TEXT_LEFT, "Progressbar" , self.prog_value);
+                    pynk.lib.nk_labelf(ctx, pynk.lib.NK_TEXT_LEFT, "Progressbar".encode('utf-8') , self.prog_value);
                     pynk.lib.nk_progress(ctx, self.prog_value, 100, pynk.lib.NK_MODIFIABLE)
 
                     pynk.lib.nk_layout_row(ctx, pynk.lib.NK_STATIC, 25, 2, self.ratio);
-                    pynk.lib.nk_label(ctx, "Property float:", pynk.lib.NK_TEXT_LEFT);
-                    pynk.lib.nk_property_float(ctx, "Float:", 0, self.property_float, 64.0, 0.1, 0.2);
-                    pynk.lib.nk_label(ctx, "Property int:", pynk.lib.NK_TEXT_LEFT);
-                    pynk.lib.nk_property_int(ctx, "Int:", 0, self.property_int, 100, 1, 1)
-                    pynk.lib.nk_label(ctx, "Property neg:", pynk.lib.NK_TEXT_LEFT);
-                    pynk.lib.nk_property_int(ctx, "Neg:", -10, self.property_neg, 10, 1, 1)
+                    pynk.lib.nk_label(ctx, "Property float:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_property_float(ctx, "Float:".encode('utf-8'), 0, self.property_float, 64.0, 0.1, 0.2);
+                    pynk.lib.nk_label(ctx, "Property int:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_property_int(ctx, "Int:".encode('utf-8'), 0, self.property_int, 100, 1, 1)
+                    pynk.lib.nk_label(ctx, "Property neg:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_property_int(ctx, "Neg:".encode('utf-8'), -10, self.property_neg, 10, 1, 1)
 
                     pynk.lib.nk_layout_row_dynamic(ctx, 25, 1);
-                    pynk.lib.nk_label(ctx, "Range:", pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_label(ctx, "Range:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                     pynk.lib.nk_layout_row_dynamic(ctx, 25, 3);
-                    pynk.lib.nk_property_float(ctx, "#min:", 0, self.range_float_min, self.range_float_max[0], 1.0, 0.2);
-                    pynk.lib.nk_property_float(ctx, "#float:", self.range_float_min[0], self.range_float_value, self.range_float_max[0], 1.0, 0.2);
-                    pynk.lib.nk_property_float(ctx, "#max:", self.range_float_min[0], self.range_float_max, 100, 1.0, 0.2);
+                    pynk.lib.nk_property_float(ctx, "#min:".encode('utf-8'), 0, self.range_float_min, self.range_float_max[0], 1.0, 0.2);
+                    pynk.lib.nk_property_float(ctx, "#float:".encode('utf-8'), self.range_float_min[0], self.range_float_value, self.range_float_max[0], 1.0, 0.2);
+                    pynk.lib.nk_property_float(ctx, "#max:".encode('utf-8'), self.range_float_min[0], self.range_float_max, 100, 1.0, 0.2);
 
-                    pynk.lib.nk_property_int(ctx, "#min:", INT_MIN, self.range_int_min, self.range_int_max[0], 1, 10);
-                    pynk.lib.nk_property_int(ctx, "#neg:", self.range_int_min[0], self.range_int_value, self.range_int_max[0], 1, 10);
-                    pynk.lib.nk_property_int(ctx, "#max:", self.range_int_min[0], self.range_int_max, INT_MAX, 1, 10);
+                    pynk.lib.nk_property_int(ctx, "#min:".encode('utf-8'), INT_MIN, self.range_int_min, self.range_int_max[0], 1, 10);
+                    pynk.lib.nk_property_int(ctx, "#neg:".encode('utf-8'), self.range_int_min[0], self.range_int_value, self.range_int_max[0], 1, 10);
+                    pynk.lib.nk_property_int(ctx, "#max:".encode('utf-8'), self.range_int_min[0], self.range_int_max, INT_MAX, 1, 10);
 
                     pynk.lib.nk_tree_pop(ctx);
                 #
-                # if (nk_tree_push(ctx, NK_TREE_NODE, "Selectable", NK_MINIMIZED))
+                # if (nk_tree_push(ctx, NK_TREE_NODE, "Selectable".encode('utf-8'), NK_MINIMIZED))
                 # {
-                #     if (nk_tree_push(ctx, NK_TREE_NODE, "List", NK_MINIMIZED))
+                #     if (nk_tree_push(ctx, NK_TREE_NODE, "List".encode('utf-8'), NK_MINIMIZED))
                 #     {
                 #         static int selected[4] = {nk_false, nk_false, nk_true, nk_false};
                 #         nk_layout_row_static(ctx, 18, 100, 1);
-                #         nk_selectable_label(ctx, "Selectable", NK_TEXT_LEFT, &selected[0]);
-                #         nk_selectable_label(ctx, "Selectable", NK_TEXT_LEFT, &selected[1]);
-                #         nk_label(ctx, "Not Selectable", NK_TEXT_LEFT);
-                #         nk_selectable_label(ctx, "Selectable", NK_TEXT_LEFT, &selected[2]);
-                #         nk_selectable_label(ctx, "Selectable", NK_TEXT_LEFT, &selected[3]);
+                #         nk_selectable_label(ctx, "Selectable".encode('utf-8'), NK_TEXT_LEFT, &selected[0]);
+                #         nk_selectable_label(ctx, "Selectable".encode('utf-8'), NK_TEXT_LEFT, &selected[1]);
+                #         nk_label(ctx, "Not Selectable".encode('utf-8'), NK_TEXT_LEFT);
+                #         nk_selectable_label(ctx, "Selectable".encode('utf-8'), NK_TEXT_LEFT, &selected[2]);
+                #         nk_selectable_label(ctx, "Selectable".encode('utf-8'), NK_TEXT_LEFT, &selected[3]);
                 #         nk_tree_pop(ctx);
                 #     }
-                #     if (nk_tree_push(ctx, NK_TREE_NODE, "Grid", NK_MINIMIZED))
+                #     if (nk_tree_push(ctx, NK_TREE_NODE, "Grid".encode('utf-8'), NK_MINIMIZED))
                 #     {
                 #         int i;
                 #         static int selected[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
                 #         nk_layout_row_static(ctx, 50, 50, 4);
                 #         for (i = 0; i < 16; ++i) {
-                #             if (nk_selectable_label(ctx, "Z", NK_TEXT_CENTERED, &selected[i])) {
+                #             if (nk_selectable_label(ctx, "Z".encode('utf-8'), NK_TEXT_CENTERED, &selected[i])) {
                 #                 int x = (i % 4), y = i / 4;
                 #                 if (x > 0) selected[i - 1] ^= 1;
                 #                 if (x < 3) selected[i + 1] ^= 1;
@@ -648,21 +648,21 @@ class Overview(object):
                 #     }
                 #     nk_tree_pop(ctx);
                 # }
-                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Selectable", pynk.lib.NK_MINIMIZED, "6"):
-                    if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "List", pynk.lib.NK_MINIMIZED, "7"):
-                        self.declare("selected1", [0, 0, 1, 0], "int[]")
+                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Selectable".encode('utf-8'), pynk.lib.NK_MINIMIZED, "6".encode('utf-8')):
+                    if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "List".encode('utf-8'), pynk.lib.NK_MINIMIZED, "7".encode('utf-8')):
+                        self.declare("selected1".encode('utf-8'), [0, 0, 1, 0], "int[]".encode('utf-8'))
                         pynk.lib.nk_layout_row_static(ctx, 18, 100, 1);
-                        pynk.lib.nk_selectable_label(ctx, "Selectable", pynk.lib.NK_TEXT_LEFT, self.selected1+0);
-                        pynk.lib.nk_selectable_label(ctx, "Selectable", pynk.lib.NK_TEXT_LEFT, self.selected1+1);
-                        pynk.lib.nk_label(ctx, "Not Selectable", pynk.lib.NK_TEXT_LEFT);
-                        pynk.lib.nk_selectable_label(ctx, "Selectable", pynk.lib.NK_TEXT_LEFT, self.selected1+2);
-                        pynk.lib.nk_selectable_label(ctx, "Selectable", pynk.lib.NK_TEXT_LEFT, self.selected1+3);
+                        pynk.lib.nk_selectable_label(ctx, "Selectable".encode('utf-8'), pynk.lib.NK_TEXT_LEFT, self.selected1+0);
+                        pynk.lib.nk_selectable_label(ctx, "Selectable".encode('utf-8'), pynk.lib.NK_TEXT_LEFT, self.selected1+1);
+                        pynk.lib.nk_label(ctx, "Not Selectable".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
+                        pynk.lib.nk_selectable_label(ctx, "Selectable".encode('utf-8'), pynk.lib.NK_TEXT_LEFT, self.selected1+2);
+                        pynk.lib.nk_selectable_label(ctx, "Selectable".encode('utf-8'), pynk.lib.NK_TEXT_LEFT, self.selected1+3);
                         pynk.lib.nk_tree_pop(ctx);
-                    if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Grid", pynk.lib.NK_MINIMIZED, "8"):
-                        self.declare("selected2", [1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1], "int[]")
+                    if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Grid".encode('utf-8'), pynk.lib.NK_MINIMIZED, "8".encode('utf-8')):
+                        self.declare("selected2".encode('utf-8'), [1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1], "int[]".encode('utf-8'))
                         pynk.lib.nk_layout_row_static(ctx, 50, 50, 4);
-                        for i in xrange(len(self.selected2)):
-                            if pynk.lib.nk_selectable_label(ctx, "Z", pynk.lib.NK_TEXT_CENTERED, self.selected2+i):
+                        for i in range(len(self.selected2)):
+                            if pynk.lib.nk_selectable_label(ctx, "Z".encode('utf-8'), pynk.lib.NK_TEXT_CENTERED, self.selected2+i):
                                 x = i % 4
                                 y = i / 4
                                 if x > 0: self.selected2[i - 1] ^= 1;
@@ -672,7 +672,7 @@ class Overview(object):
                         pynk.lib.nk_tree_pop(ctx);
                     pynk.lib.nk_tree_pop(ctx);
                 #
-                # if (nk_tree_push(ctx, NK_TREE_NODE, "Combo", NK_MINIMIZED))
+                # if (nk_tree_push(ctx, NK_TREE_NODE, "Combo".encode('utf-8'), NK_MINIMIZED))
                 # {
                 #     /* Combobox Widgets
                 #      * In this library comboboxes are not limited to being a popup
@@ -701,7 +701,7 @@ class Overview(object):
                 #      * which only show the currently activated time/data and hide the
                 #      * selection logic inside the combobox popup.
                 #      */
-                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Combo", pynk.lib.NK_MINIMIZED, "9"):
+                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Combo".encode('utf-8'), pynk.lib.NK_MINIMIZED, "9".encode('utf-8')):
                     # static float chart_selection = 8.0f;
                     # static int current_weapon = 0;
                     # static int check_values[5];
@@ -709,21 +709,21 @@ class Overview(object):
                     # static struct nk_color combo_color = {130, 50, 50, 255};
                     # static struct nk_color combo_color2 = {130, 180, 50, 255};
                     # static size_t prog_a =  20, prog_b = 40, prog_c = 10, prog_d = 90;
-                    # static const char *weapons[] = {"Fist","Pistol","Shotgun","Plasma","BFG"};
+                    # static const char *weapons[] = {"Fist".encode('utf-8'),"Pistol",".encode('utf-8')Shotgun",".encode('utf-8')Plasma",".encode('utf-8')BFG"};
                     #
                     # char buffer[64];
                     # size_t sum = 0;
-                    self.declare("chart_selection", 8.0, "float*")
-                    self.declare("current_weapon", 0, "int*")
-                    self.declare("check_values", [0, 0, 0, 0, 0], "int[]")
-                    self.declare("position", [0, 0, 0], "float[]")
-                    self.declare("combo_color", [130, 50, 50, 255], "struct nk_color*")
-                    self.declare("combo_color2", [130, 180, 50, 255], "struct nk_color*")
-                    self.declare("prog_a", 20, "unsigned int*")
-                    self.declare("prog_b", 40, "unsigned int*")
-                    self.declare("prog_c", 10, "unsigned int*")
-                    self.declare("prog_d", 90, "unsigned int*")
-                    self.declare_string_array("weapons", ["Fist", "Pistol", "Shotgun", "Plasma", "BFG"])
+                    self.declare("chart_selection".encode('utf-8'), 8.0, "float*".encode('utf-8'))
+                    self.declare("current_weapon".encode('utf-8'), 0, "int*".encode('utf-8'))
+                    self.declare("check_values".encode('utf-8'), [0, 0, 0, 0, 0], "int[]".encode('utf-8'))
+                    self.declare("position".encode('utf-8'), [0, 0, 0], "float[]".encode('utf-8'))
+                    self.declare("combo_color".encode('utf-8'), [130, 50, 50, 255], "struct nk_color*".encode('utf-8'))
+                    self.declare("combo_color2".encode('utf-8'), [130, 180, 50, 255], "struct nk_color*".encode('utf-8'))
+                    self.declare("prog_a".encode('utf-8'), 20, "unsigned int*".encode('utf-8'))
+                    self.declare("prog_b".encode('utf-8'), 40, "unsigned int*".encode('utf-8'))
+                    self.declare("prog_c".encode('utf-8'), 10, "unsigned int*".encode('utf-8'))
+                    self.declare("prog_d".encode('utf-8'), 90, "unsigned int*".encode('utf-8'))
+                    self.declare_string_array("weapons".encode('utf-8'), ["Fist".encode('utf-8'), "Pistol".encode('utf-8'), "Shotgun".encode('utf-8'), "Plasma".encode('utf-8'), "BFG".encode('utf-8')])
                     #
                     # /* default combobox */
                     # nk_layout_row_static(ctx, 25, 200, 1);
@@ -736,26 +736,26 @@ class Overview(object):
                     # if (nk_combo_begin_color(ctx, combo_color, nk_vec2(200,200))) {
                     #     float ratios[] = {0.15f, 0.85f};
                     #     nk_layout_row(ctx, NK_DYNAMIC, 30, 2, ratios);
-                    #     nk_label(ctx, "R:", NK_TEXT_LEFT);
+                    #     nk_label(ctx, "R:".encode('utf-8'), NK_TEXT_LEFT);
                     #     combo_color.r = (nk_byte)nk_slide_int(ctx, 0, combo_color.r, 255, 5);
-                    #     nk_label(ctx, "G:", NK_TEXT_LEFT);
+                    #     nk_label(ctx, "G:".encode('utf-8'), NK_TEXT_LEFT);
                     #     combo_color.g = (nk_byte)nk_slide_int(ctx, 0, combo_color.g, 255, 5);
-                    #     nk_label(ctx, "B:", NK_TEXT_LEFT);
+                    #     nk_label(ctx, "B:".encode('utf-8'), NK_TEXT_LEFT);
                     #     combo_color.b = (nk_byte)nk_slide_int(ctx, 0, combo_color.b, 255, 5);
-                    #     nk_label(ctx, "A:", NK_TEXT_LEFT);
+                    #     nk_label(ctx, "A:".encode('utf-8'), NK_TEXT_LEFT);
                     #     combo_color.a = (nk_byte)nk_slide_int(ctx, 0, combo_color.a , 255, 5);
                     #     nk_combo_end(ctx);
                     # }
                     if pynk.lib.nk_combo_begin_color(ctx, self.combo_color[0], pynk.lib.nk_vec2(200,200)):
                         ratios = pynk.ffi.new("float[2]", [0.15, 0.85])
                         pynk.lib.nk_layout_row(ctx, pynk.lib.NK_DYNAMIC, 30, 2, ratios)
-                        pynk.lib.nk_label(ctx, "R:", pynk.lib.NK_TEXT_LEFT)
+                        pynk.lib.nk_label(ctx, "R:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT)
                         self.combo_color.r = pynk.lib.nk_slide_int(ctx, 0, self.combo_color.r, 255, 5)
-                        pynk.lib.nk_label(ctx, "G:", pynk.lib.NK_TEXT_LEFT)
+                        pynk.lib.nk_label(ctx, "G:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT)
                         self.combo_color.g = pynk.lib.nk_slide_int(ctx, 0, self.combo_color.g, 255, 5)
-                        pynk.lib.nk_label(ctx, "B:", pynk.lib.NK_TEXT_LEFT)
+                        pynk.lib.nk_label(ctx, "B:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT)
                         self.combo_color.b = pynk.lib.nk_slide_int(ctx, 0, self.combo_color.b, 255, 5)
-                        pynk.lib.nk_label(ctx, "A:", pynk.lib.NK_TEXT_LEFT)
+                        pynk.lib.nk_label(ctx, "A:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT)
                         self.combo_color.a = pynk.lib.nk_slide_int(ctx, 0, self.combo_color.a , 255, 5)
                         pynk.lib.nk_combo_end(ctx);
                     #
@@ -769,22 +769,22 @@ class Overview(object):
                     #     #endif
                     #
                     #     nk_layout_row_dynamic(ctx, 25, 2);
-                    #     col_mode = nk_option_label(ctx, "RGB", col_mode == COL_RGB) ? COL_RGB : col_mode;
-                    #     col_mode = nk_option_label(ctx, "HSV", col_mode == COL_HSV) ? COL_HSV : col_mode;
+                    #     col_mode = nk_option_label(ctx, "RGB".encode('utf-8'), col_mode == COL_RGB) ? COL_RGB : col_mode;
+                    #     col_mode = nk_option_label(ctx, "HSV".encode('utf-8'), col_mode == COL_HSV) ? COL_HSV : col_mode;
                     #
                     #     nk_layout_row_dynamic(ctx, 25, 1);
                     #     if (col_mode == COL_RGB) {
-                    #         combo_color2.r = (nk_byte)nk_propertyi(ctx, "#R:", 0, combo_color2.r, 255, 1,1);
-                    #         combo_color2.g = (nk_byte)nk_propertyi(ctx, "#G:", 0, combo_color2.g, 255, 1,1);
-                    #         combo_color2.b = (nk_byte)nk_propertyi(ctx, "#B:", 0, combo_color2.b, 255, 1,1);
-                    #         combo_color2.a = (nk_byte)nk_propertyi(ctx, "#A:", 0, combo_color2.a, 255, 1,1);
+                    #         combo_color2.r = (nk_byte)nk_propertyi(ctx, "#R:".encode('utf-8'), 0, combo_color2.r, 255, 1,1);
+                    #         combo_color2.g = (nk_byte)nk_propertyi(ctx, "#G:".encode('utf-8'), 0, combo_color2.g, 255, 1,1);
+                    #         combo_color2.b = (nk_byte)nk_propertyi(ctx, "#B:".encode('utf-8'), 0, combo_color2.b, 255, 1,1);
+                    #         combo_color2.a = (nk_byte)nk_propertyi(ctx, "#A:".encode('utf-8'), 0, combo_color2.a, 255, 1,1);
                     #     } else {
                     #         nk_byte tmp[4];
                     #         nk_color_hsva_bv(tmp, combo_color2);
-                    #         tmp[0] = (nk_byte)nk_propertyi(ctx, "#H:", 0, tmp[0], 255, 1,1);
-                    #         tmp[1] = (nk_byte)nk_propertyi(ctx, "#S:", 0, tmp[1], 255, 1,1);
-                    #         tmp[2] = (nk_byte)nk_propertyi(ctx, "#V:", 0, tmp[2], 255, 1,1);
-                    #         tmp[3] = (nk_byte)nk_propertyi(ctx, "#A:", 0, tmp[3], 255, 1,1);
+                    #         tmp[0] = (nk_byte)nk_propertyi(ctx, "#H:".encode('utf-8'), 0, tmp[0], 255, 1,1);
+                    #         tmp[1] = (nk_byte)nk_propertyi(ctx, "#S:".encode('utf-8'), 0, tmp[1], 255, 1,1);
+                    #         tmp[2] = (nk_byte)nk_propertyi(ctx, "#V:".encode('utf-8'), 0, tmp[2], 255, 1,1);
+                    #         tmp[3] = (nk_byte)nk_propertyi(ctx, "#A:".encode('utf-8'), 0, tmp[3], 255, 1,1);
                     #         combo_color2 = nk_hsva_bv(tmp);
                     #     }
                     #     nk_combo_end(ctx);
@@ -792,35 +792,35 @@ class Overview(object):
                     if pynk.lib.nk_combo_begin_color(ctx, self.combo_color2[0], pynk.lib.nk_vec2(200,400)):
                         COL_RGB = 0
                         COL_HSV = 1
-                        self.declare("col_mode", COL_RGB, "int*")
+                        self.declare("col_mode".encode('utf-8'), COL_RGB, "int*".encode('utf-8'))
                         pynk.lib.nk_layout_row_dynamic(ctx, 120, 1);
                         self.combo_color2[0] = pynk.lib.nk_color_picker(ctx, self.combo_color2[0], pynk.lib.NK_RGBA);
 
                         pynk.lib.nk_layout_row_dynamic(ctx, 25, 2);
-                        if pynk.lib.nk_option_label(ctx, "RGB", self.col_mode[0] == COL_RGB):
+                        if pynk.lib.nk_option_label(ctx, "RGB".encode('utf-8'), self.col_mode[0] == COL_RGB):
                             self.col_mode[0] = COL_RGB
-                        if pynk.lib.nk_option_label(ctx, "HSV", self.col_mode[0] == COL_HSV):
+                        if pynk.lib.nk_option_label(ctx, "HSV".encode('utf-8'), self.col_mode[0] == COL_HSV):
                             self.col_mode[0] = COL_HSV
 
                         pynk.lib.nk_layout_row_dynamic(ctx, 25, 1);
                         if self.col_mode[0] == COL_RGB:
-                            self.combo_color2.r = pynk.lib.nk_propertyi(ctx, "#R:", 0, self.combo_color2.r, 255, 1,1);
-                            self.combo_color2.g = pynk.lib.nk_propertyi(ctx, "#G:", 0, self.combo_color2.g, 255, 1,1);
-                            self.combo_color2.b = pynk.lib.nk_propertyi(ctx, "#B:", 0, self.combo_color2.b, 255, 1,1);
-                            self.combo_color2.a = pynk.lib.nk_propertyi(ctx, "#A:", 0, self.combo_color2.a, 255, 1,1);
+                            self.combo_color2.r = pynk.lib.nk_propertyi(ctx, "#R:".encode('utf-8'), 0, self.combo_color2.r, 255, 1,1);
+                            self.combo_color2.g = pynk.lib.nk_propertyi(ctx, "#G:".encode('utf-8'), 0, self.combo_color2.g, 255, 1,1);
+                            self.combo_color2.b = pynk.lib.nk_propertyi(ctx, "#B:".encode('utf-8'), 0, self.combo_color2.b, 255, 1,1);
+                            self.combo_color2.a = pynk.lib.nk_propertyi(ctx, "#A:".encode('utf-8'), 0, self.combo_color2.a, 255, 1,1);
                         else:
                             tmp = pynk.ffi.new("nk_byte[4]")
                             pynk.lib.nk_color_hsva_bv(tmp, self.combo_color2[0]);
-                            tmp[0] = pynk.lib.nk_propertyi(ctx, "#H:", 0, tmp[0], 255, 1,1);
-                            tmp[1] = pynk.lib.nk_propertyi(ctx, "#S:", 0, tmp[1], 255, 1,1);
-                            tmp[2] = pynk.lib.nk_propertyi(ctx, "#V:", 0, tmp[2], 255, 1,1);
-                            tmp[3] = pynk.lib.nk_propertyi(ctx, "#A:", 0, tmp[3], 255, 1,1);
+                            tmp[0] = pynk.lib.nk_propertyi(ctx, "#H:".encode('utf-8'), 0, tmp[0], 255, 1,1);
+                            tmp[1] = pynk.lib.nk_propertyi(ctx, "#S:".encode('utf-8'), 0, tmp[1], 255, 1,1);
+                            tmp[2] = pynk.lib.nk_propertyi(ctx, "#V:".encode('utf-8'), 0, tmp[2], 255, 1,1);
+                            tmp[3] = pynk.lib.nk_propertyi(ctx, "#A:".encode('utf-8'), 0, tmp[3], 255, 1,1);
                             self.combo_color2[0] = pynk.lib.nk_hsva_bv(tmp);
                         pynk.lib.nk_combo_end(ctx);
                     #
                     # /* progressbar combobox */
                     # sum = prog_a + prog_b + prog_c + prog_d;
-                    # sprintf(buffer, "%lu", sum);
+                    # sprintf(buffer, "%lu".encode('utf-8'), sum);
                     # if (nk_combo_begin_label(ctx, buffer, nk_vec2(200,200))) {
                     #     nk_layout_row_dynamic(ctx, 30, 1);
                     #     nk_progress(ctx, &prog_a, 100, NK_MODIFIABLE);
@@ -840,7 +840,7 @@ class Overview(object):
                     #
                     # /* checkbox combobox */
                     # sum = (size_t)(check_values[0] + check_values[1] + check_values[2] + check_values[3] + check_values[4]);
-                    # sprintf(buffer, "%lu", sum);
+                    # sprintf(buffer, "%lu".encode('utf-8'), sum);
                     # if (nk_combo_begin_label(ctx, buffer, nk_vec2(200,200))) {
                     #     nk_layout_row_dynamic(ctx, 30, 1);
                     #     nk_checkbox_label(ctx, weapons[0], &check_values[0]);
@@ -859,24 +859,24 @@ class Overview(object):
                         pynk.lib.nk_combo_end(ctx);
                     #
                     # /* complex text combobox */
-                    # sprintf(buffer, "%.2f, %.2f, %.2f", position[0], position[1],position[2]);
+                    # sprintf(buffer, "%.2f, %.2f, %.2f".encode('utf-8'), position[0], position[1],position[2]);
                     # if (nk_combo_begin_label(ctx, buffer, nk_vec2(200,200))) {
                     #     nk_layout_row_dynamic(ctx, 25, 1);
-                    #     nk_property_float(ctx, "#X:", -1024.0f, &position[0], 1024.0f, 1,0.5f);
-                    #     nk_property_float(ctx, "#Y:", -1024.0f, &position[1], 1024.0f, 1,0.5f);
-                    #     nk_property_float(ctx, "#Z:", -1024.0f, &position[2], 1024.0f, 1,0.5f);
+                    #     nk_property_float(ctx, "#X:".encode('utf-8'), -1024.0f, &position[0], 1024.0f, 1,0.5f);
+                    #     nk_property_float(ctx, "#Y:".encode('utf-8'), -1024.0f, &position[1], 1024.0f, 1,0.5f);
+                    #     nk_property_float(ctx, "#Z:".encode('utf-8'), -1024.0f, &position[2], 1024.0f, 1,0.5f);
                     #     nk_combo_end(ctx);
                     # }
-                    lab = "%s, %s, %s" % (self.position[0], self.position[1], self.position[2])
+                    lab = "%s, %s, %s".encode('utf-8') % (self.position[0], self.position[1], self.position[2])
                     if pynk.lib.nk_combo_begin_label(ctx, lab, pynk.lib.nk_vec2(200,200)):
                         pynk.lib.nk_layout_row_dynamic(ctx, 25, 1);
-                        pynk.lib.nk_property_float(ctx, "#X:", -1024.0, self.position, 1024.0, 1,0.5);
-                        pynk.lib.nk_property_float(ctx, "#Y:", -1024.0, self.position+1, 1024.0, 1,0.5);
-                        pynk.lib.nk_property_float(ctx, "#Z:", -1024.0, self.position+2, 1024.0, 1,0.5);
+                        pynk.lib.nk_property_float(ctx, "#X:".encode('utf-8'), -1024.0, self.position, 1024.0, 1,0.5);
+                        pynk.lib.nk_property_float(ctx, "#Y:".encode('utf-8'), -1024.0, self.position+1, 1024.0, 1,0.5);
+                        pynk.lib.nk_property_float(ctx, "#Z:".encode('utf-8'), -1024.0, self.position+2, 1024.0, 1,0.5);
                         pynk.lib.nk_combo_end(ctx);
                     #
                     # /* chart combobox */
-                    # sprintf(buffer, "%.1f", chart_selection);
+                    # sprintf(buffer, "%.1f".encode('utf-8'), chart_selection);
                     # if (nk_combo_begin_label(ctx, buffer, nk_vec2(200,250))) {
                     #     size_t i = 0;
                     #     static const float values[]={26.0f,13.0f,30.0f,15.0f,25.0f,10.0f,20.0f,40.0f, 12.0f, 8.0f, 22.0f, 28.0f, 5.0f};
@@ -896,7 +896,7 @@ class Overview(object):
                         values = [26.0,13.0,30.0,15.0,25.0,10.0,20.0,40.0, 12.0, 8.0, 22.0, 28.0, 5.0]
                         pynk.lib.nk_layout_row_dynamic(ctx, 150, 1);
                         pynk.lib.nk_chart_begin(ctx, pynk.lib.NK_CHART_COLUMN, len(values), 0, 50);
-                        for i in xrange(len(values)):
+                        for i in range(len(values)):
                             res = pynk.lib.nk_chart_push(ctx, values[i]);
                             if res & pynk.lib.NK_CHART_CLICKED:
                                 self.chart_selection[0] = values[i];
@@ -917,10 +917,10 @@ class Overview(object):
                     #    if (!date_selected)
                     #        memcpy(&sel_date, n, sizeof(struct tm));
                     #}
-                    self.declare("time_selected", False)
-                    self.declare("date_selected", False)
-                    self.declare("sel_time", None)
-                    self.declare("sel_date", None)
+                    self.declare("time_selected".encode('utf-8'), False)
+                    self.declare("date_selected".encode('utf-8'), False)
+                    self.declare("sel_time".encode('utf-8'), None)
+                    self.declare("sel_date".encode('utf-8'), None)
                     cur_time = datetime.datetime.now()
                     if not self.time_selected:
                         self.sel_time = cur_time
@@ -928,41 +928,41 @@ class Overview(object):
                         self.sel_date = cur_time
                     #
                     #/* time combobox */
-                    #sprintf(buffer, "%02d:%02d:%02d", sel_time.tm_hour, sel_time.tm_min, sel_time.tm_sec);
-                    sel_time_str = self.sel_time.strftime("%H:%M:%S")
+                    #sprintf(buffer, "%02d:%02d:%02d".encode('utf-8'), sel_time.tm_hour, sel_time.tm_min, sel_time.tm_sec);
+                    sel_time_str = self.sel_time.strftime("%H:%M:%S".encode('utf-8'))
                     #if (nk_combo_begin_label(ctx, buffer, nk_vec2(200,250))) {
                     #    time_selected = 1;
                     #    nk_layout_row_dynamic(ctx, 25, 1);
-                    #    sel_time.tm_sec = nk_propertyi(ctx, "#S:", 0, sel_time.tm_sec, 60, 1, 1);
-                    #    sel_time.tm_min = nk_propertyi(ctx, "#M:", 0, sel_time.tm_min, 60, 1, 1);
-                    #    sel_time.tm_hour = nk_propertyi(ctx, "#H:", 0, sel_time.tm_hour, 23, 1, 1);
+                    #    sel_time.tm_sec = nk_propertyi(ctx, "#S:".encode('utf-8'), 0, sel_time.tm_sec, 60, 1, 1);
+                    #    sel_time.tm_min = nk_propertyi(ctx, "#M:".encode('utf-8'), 0, sel_time.tm_min, 60, 1, 1);
+                    #    sel_time.tm_hour = nk_propertyi(ctx, "#H:".encode('utf-8'), 0, sel_time.tm_hour, 23, 1, 1);
                     #    nk_combo_end(ctx);
                     #}
                     if pynk.lib.nk_combo_begin_label(ctx, sel_time_str, pynk.lib.nk_vec2(200,250)):
                         self.time_selected = True;
                         pynk.lib.nk_layout_row_dynamic(ctx, 25, 1);
-                        self.sel_time.second = pynk.lib.nk_propertyi(ctx, "#S:", 0, self.sel_time.second, 60, 1, 1);
-                        self.sel_time.minute = pynk.lib.nk_propertyi(ctx, "#M:", 0, self.sel_time.minute, 60, 1, 1);
-                        self.sel_time.hour = pynk.lib.nk_propertyi(ctx, "#H:", 0, self.sel_time.hour, 23, 1, 1);
+                        self.sel_time.second = pynk.lib.nk_propertyi(ctx, "#S:".encode('utf-8'), 0, self.sel_time.second, 60, 1, 1);
+                        self.sel_time.minute = pynk.lib.nk_propertyi(ctx, "#M:".encode('utf-8'), 0, self.sel_time.minute, 60, 1, 1);
+                        self.sel_time.hour = pynk.lib.nk_propertyi(ctx, "#H:".encode('utf-8'), 0, self.sel_time.hour, 23, 1, 1);
                         pynk.lib.nk_combo_end(ctx);
                     #
                     #/* date combobox */
-                    #sprintf(buffer, "%02d-%02d-%02d", sel_date.tm_mday, sel_date.tm_mon+1, sel_date.tm_year+1900);
+                    #sprintf(buffer, "%02d-%02d-%02d".encode('utf-8'), sel_date.tm_mday, sel_date.tm_mon+1, sel_date.tm_year+1900);
                     #if (nk_combo_begin_label(ctx, buffer, nk_vec2(350,400)))
                     #{
-                    sel_date_str = self.sel_date.strftime("%d-%m-%y")
+                    sel_date_str = self.sel_date.strftime("%d-%m-%y".encode('utf-8'))
                     if pynk.lib.nk_combo_begin_label(ctx, sel_date_str, pynk.lib.nk_vec2(350,400)):
                         # int i = 0;
-                        # const char *month[] = {"January", "February", "March", "Apil", "May", "June", "July", "August", "September", "Ocotober", "November", "December"};
-                        # const char *week_days[] = {"SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"};
+                        # const char *month[] = {"January".encode('utf-8'), "February".encode('utf-8'), "March".encode('utf-8'), "Apil".encode('utf-8'), "May".encode('utf-8'), "June".encode('utf-8'), "July".encode('utf-8'), "August".encode('utf-8'), "September".encode('utf-8'), "Ocotober".encode('utf-8'), "November".encode('utf-8'), "December".encode('utf-8')};
+                        # const char *week_days[] = {"SUN".encode('utf-8'), "MON".encode('utf-8'), "TUE".encode('utf-8'), "WED".encode('utf-8'), "THU".encode('utf-8'), "FRI".encode('utf-8'), "SAT".encode('utf-8')};
                         # const int month_days[] = {31,28,31,30,31,30,31,31,30,31,30,31};
                         # int year = sel_date.tm_year+1900;
                         # int leap_year = (!(year % 4) && ((year % 100))) || !(year % 400);
                         # int days = (sel_date.tm_mon == 1) ?
                         #     month_days[sel_date.tm_mon] + leap_year:
                         #     month_days[sel_date.tm_mon];
-                        month = ["January", "February", "March", "Apil", "May", "June", "July", "August", "September", "Ocotober", "November", "December"]
-                        week_days = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"]
+                        month = ["January".encode('utf-8'), "February".encode('utf-8'), "March".encode('utf-8'), "Apil".encode('utf-8'), "May".encode('utf-8'), "June".encode('utf-8'), "July".encode('utf-8'), "August".encode('utf-8'), "September".encode('utf-8'), "Ocotober".encode('utf-8'), "November".encode('utf-8'), "December".encode('utf-8')]
+                        week_days = ["SUN".encode('utf-8'), "MON".encode('utf-8'), "TUE".encode('utf-8'), "WED".encode('utf-8'), "THU".encode('utf-8'), "FRI".encode('utf-8'), "SAT".encode('utf-8')]
                         month_days = [31,28,31,30,31,30,31,31,30,31,30,31]
                         year = self.sel_date.year+1900;
                         leap_year = (not (year % 4) and ((year % 100))) or not (year % 400)
@@ -980,7 +980,7 @@ class Overview(object):
                         #     } else sel_date.tm_mon--;
                         # }
                         # nk_layout_row_push(ctx, 0.9f);
-                        # sprintf(buffer, "%s %d", month[sel_date.tm_mon], year);
+                        # sprintf(buffer, "%s %d".encode('utf-8'), month[sel_date.tm_mon], year);
                         # nk_label(ctx, buffer, NK_TEXT_CENTERED);
                         # nk_layout_row_push(ctx, 0.05f);
                         # if (nk_button_symbol(ctx, NK_SYMBOL_TRIANGLE_RIGHT)) {
@@ -1000,7 +1000,7 @@ class Overview(object):
                             else:
                                 self.sel_date.month -= 1
                         pynk.lib.nk_layout_row_push(ctx, 0.9)
-                        buf = "%s %s" % (month[self.sel_date.month], year)
+                        buf = "%s %s".encode('utf-8') % (month[self.sel_date.month], year)
                         pynk.lib.nk_label(ctx, buf, pynk.lib.NK_TEXT_CENTERED);
                         pynk.lib.nk_layout_row_push(ctx, 0.05);
                         if pynk.lib.nk_button_symbol(ctx, pynk.lib.NK_SYMBOL_TRIANGLE_RIGHT):
@@ -1029,7 +1029,7 @@ class Overview(object):
                         # /* days  */
                         # if (week_day > 0) nk_spacing(ctx, week_day);
                         # for (i = 1; i <= days; ++i) {
-                        #     sprintf(buffer, "%d", i);
+                        #     sprintf(buffer, "%d".encode('utf-8'), i);
                         #     if (nk_button_label(ctx, buffer)) {
                         #         sel_date.tm_mday = i;
                         #         nk_combo_close(ctx);
@@ -1061,9 +1061,9 @@ class Overview(object):
                     # nk_tree_pop(ctx);
                     pynk.lib.nk_tree_pop(ctx)
                 # }
-                # if (nk_tree_push(ctx, NK_TREE_NODE, "Input", NK_MINIMIZED))
+                # if (nk_tree_push(ctx, NK_TREE_NODE, "Input".encode('utf-8'), NK_MINIMIZED))
                 # {
-                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Input", pynk.lib.NK_MINIMIZED, "10"):
+                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Input".encode('utf-8'), pynk.lib.NK_MINIMIZED, "10".encode('utf-8')):
                     # static const float ratio[] = {120, 150};
                     # static char field_buffer[64];
                     # static char text[9][64];
@@ -1072,51 +1072,51 @@ class Overview(object):
                     # static int field_len;
                     # static int box_len;
                     # nk_flags active;
-                    self.declare("ratio", [120, 150], "float[]")
-                    self.declare("field_buffer", ["a"]*64, "char[]")
-                    self.declare_string_buffers("text", 9, 64)
-                    self.declare("text_len", [0]*9, "int[]")
-                    self.declare("box_buffer", ["a"]*512, "char[]")
-                    self.declare("field_len", 0, "int*")
-                    self.declare("box_len", 0, "int*")
+                    self.declare("ratio".encode('utf-8'), [120, 150], "float[]".encode('utf-8'))
+                    self.declare("field_buffer".encode('utf-8'), ["a".encode('utf-8')]*64, "char[]".encode('utf-8'))
+                    self.declare_string_buffers("text".encode('utf-8'), 9, 64)
+                    self.declare("text_len".encode('utf-8'), [0]*9, "int[]".encode('utf-8'))
+                    self.declare("box_buffer".encode('utf-8'), ["a".encode('utf-8')]*512, "char[]".encode('utf-8'))
+                    self.declare("field_len".encode('utf-8'), 0, "int*".encode('utf-8'))
+                    self.declare("box_len".encode('utf-8'), 0, "int*".encode('utf-8'))
                     active = 0
 
     #
-                    # nk_layout_row(ctx, NK_STATIC, 25, 2, ratio); #                 nk_label(ctx, "Default:", NK_TEXT_LEFT);
+                    # nk_layout_row(ctx, NK_STATIC, 25, 2, ratio); #                 nk_label(ctx, "Default:".encode('utf-8'), NK_TEXT_LEFT);
                     #
                     # nk_edit_string(ctx, NK_EDIT_SIMPLE, text[0], &text_len[0], 64, nk_filter_default);
-                    # nk_label(ctx, "Int:", NK_TEXT_LEFT);
+                    # nk_label(ctx, "Int:".encode('utf-8'), NK_TEXT_LEFT);
                     # nk_edit_string(ctx, NK_EDIT_SIMPLE, text[1], &text_len[1], 64, nk_filter_decimal);
-                    # nk_label(ctx, "Float:", NK_TEXT_LEFT);
+                    # nk_label(ctx, "Float:".encode('utf-8'), NK_TEXT_LEFT);
                     # nk_edit_string(ctx, NK_EDIT_SIMPLE, text[2], &text_len[2], 64, nk_filter_float);
-                    # nk_label(ctx, "Hex:", NK_TEXT_LEFT);
+                    # nk_label(ctx, "Hex:".encode('utf-8'), NK_TEXT_LEFT);
                     # nk_edit_string(ctx, NK_EDIT_SIMPLE, text[4], &text_len[4], 64, nk_filter_hex);
-                    # nk_label(ctx, "Octal:", NK_TEXT_LEFT);
+                    # nk_label(ctx, "Octal:".encode('utf-8'), NK_TEXT_LEFT);
                     # nk_edit_string(ctx, NK_EDIT_SIMPLE, text[5], &text_len[5], 64, nk_filter_oct);
-                    # nk_label(ctx, "Binary:", NK_TEXT_LEFT);
+                    # nk_label(ctx, "Binary:".encode('utf-8'), NK_TEXT_LEFT);
                     # nk_edit_string(ctx, NK_EDIT_SIMPLE, text[6], &text_len[6], 64, nk_filter_binary);
     #
-                    pynk.lib.nk_layout_row(ctx, pynk.lib.NK_STATIC, 25, 2, self.ratio); #                 nk_label(ctx, "Default:", NK_TEXT_LEFT);
+                    pynk.lib.nk_layout_row(ctx, pynk.lib.NK_STATIC, 25, 2, self.ratio); #                 nk_label(ctx, "Default:".encode('utf-8'), NK_TEXT_LEFT);
 
                     pynk.lib.nk_edit_string(ctx, pynk.lib.NK_EDIT_SIMPLE, self.text[0],
-                                            self.text_len+0, 64, pynk.ffi.addressof(pynk.lib, "nk_filter_default"));
-                    pynk.lib.nk_label(ctx, "Int:", pynk.lib.NK_TEXT_LEFT);
+                                            self.text_len+0, 64, pynk.ffi.addressof(pynk.lib, "nk_filter_default".encode('utf-8')));
+                    pynk.lib.nk_label(ctx, "Int:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                     pynk.lib.nk_edit_string(ctx, pynk.lib.NK_EDIT_SIMPLE, self.text[1], self.text_len+1,
-                                            64, pynk.ffi.addressof(pynk.lib, "nk_filter_decimal"));
-                    pynk.lib.nk_label(ctx, "Float:", pynk.lib.NK_TEXT_LEFT);
+                                            64, pynk.ffi.addressof(pynk.lib, "nk_filter_decimal".encode('utf-8')));
+                    pynk.lib.nk_label(ctx, "Float:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                     pynk.lib.nk_edit_string(ctx, pynk.lib.NK_EDIT_SIMPLE, self.text[2],
-                                            self.text_len+2, 64, pynk.ffi.addressof(pynk.lib, "nk_filter_float"));
-                    pynk.lib.nk_label(ctx, "Hex:", pynk.lib.NK_TEXT_LEFT);
+                                            self.text_len+2, 64, pynk.ffi.addressof(pynk.lib, "nk_filter_float".encode('utf-8')));
+                    pynk.lib.nk_label(ctx, "Hex:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                     pynk.lib.nk_edit_string(ctx, pynk.lib.NK_EDIT_SIMPLE, self.text[4],
-                                            self.text_len+4, 64, pynk.ffi.addressof(pynk.lib, "nk_filter_hex"));
-                    pynk.lib.nk_label(ctx, "Octal:", pynk.lib.NK_TEXT_LEFT);
+                                            self.text_len+4, 64, pynk.ffi.addressof(pynk.lib, "nk_filter_hex".encode('utf-8')));
+                    pynk.lib.nk_label(ctx, "Octal:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                     pynk.lib.nk_edit_string(ctx, pynk.lib.NK_EDIT_SIMPLE, self.text[5],
-                                            self.text_len+5, 64, pynk.ffi.addressof(pynk.lib, "nk_filter_oct"));
-                    pynk.lib.nk_label(ctx, "Binary:", pynk.lib.NK_TEXT_LEFT);
+                                            self.text_len+5, 64, pynk.ffi.addressof(pynk.lib, "nk_filter_oct".encode('utf-8')));
+                    pynk.lib.nk_label(ctx, "Binary:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                     pynk.lib.nk_edit_string(ctx, pynk.lib.NK_EDIT_SIMPLE, self.text[6],
-                                           self.text_len+6, 64, pynk.ffi.addressof(pynk.lib, "nk_filter_binary"));
+                                           self.text_len+6, 64, pynk.ffi.addressof(pynk.lib, "nk_filter_binary".encode('utf-8')));
                     #
-                    # nk_label(ctx, "Password:", NK_TEXT_LEFT);
+                    # nk_label(ctx, "Password:".encode('utf-8'), NK_TEXT_LEFT);
                     # {
                     #     int i = 0;
                     #     int old_len = text_len[8];
@@ -1126,39 +1126,39 @@ class Overview(object):
                     #     if (old_len < text_len[8])
                     #         memcpy(&text[8][old_len], &buffer[old_len], (nk_size)(text_len[8] - old_len));
                     # }
-                    pynk.lib.nk_label(ctx, "Password:", pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_label(ctx, "Password:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                     old_len = self.text_len[8];
                     buf = pynk.ffi.new("char[64]")
                     for i in range(0, self.text_len[8]):
                         buf[i] = "*"
                     pynk.lib.nk_edit_string(ctx, pynk.lib.NK_EDIT_FIELD, buf, self.text_len+8,
-                                            64, pynk.ffi.addressof(pynk.lib, "nk_filter_default"));
+                                            64, pynk.ffi.addressof(pynk.lib, "nk_filter_default".encode('utf-8')));
                     if old_len < self.text_len[8]:
                         self.memcpy(self.text+8, old_len, buf, old_len, self.text_len[8] - old_len);
                     #
-                    #  nk_label(ctx, "Field:", NK_TEXT_LEFT);
+                    #  nk_label(ctx, "Field:".encode('utf-8'), NK_TEXT_LEFT);
                     #  nk_edit_string(ctx, NK_EDIT_FIELD, field_buffer, &field_len, 64, nk_filter_default);
                     #
-                    #  nk_label(ctx, "Box:", NK_TEXT_LEFT);
+                    #  nk_label(ctx, "Box:".encode('utf-8'), NK_TEXT_LEFT);
                     #  nk_layout_row_static(ctx, 180, 278, 1);
                     #  nk_edit_string(ctx, NK_EDIT_BOX, box_buffer, &box_len, 512, nk_filter_default);
                     #
                     #  nk_layout_row(ctx, NK_STATIC, 25, 2, ratio);
                     #  active = nk_edit_string(ctx, NK_EDIT_FIELD|NK_EDIT_SIG_ENTER, text[7], &text_len[7], 64,  nk_filter_ascii);
 
-                    pynk.lib.nk_label(ctx, "Field:", pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_label(ctx, "Field:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                     pynk.lib.nk_edit_string(ctx, pynk.lib.NK_EDIT_FIELD, self.field_buffer,
-                                            self.field_len, 64, pynk.ffi.addressof(pynk.lib, "nk_filter_default"));
+                                            self.field_len, 64, pynk.ffi.addressof(pynk.lib, "nk_filter_default".encode('utf-8')));
 
-                    pynk.lib.nk_label(ctx, "Box:", pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_label(ctx, "Box:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                     pynk.lib.nk_layout_row_static(ctx, 180, 278, 1);
                     pynk.lib.nk_edit_string(ctx, pynk.lib.NK_EDIT_BOX, self.box_buffer, self.box_len,
-                                            512, pynk.ffi.addressof(pynk.lib, "nk_filter_default"));
+                                            512, pynk.ffi.addressof(pynk.lib, "nk_filter_default".encode('utf-8')));
 
                     pynk.lib.nk_layout_row(ctx, pynk.lib.NK_STATIC, 25, 2, self.ratio);
                     active = pynk.lib.nk_edit_string(ctx, pynk.lib.NK_EDIT_FIELD|pynk.lib.NK_EDIT_SIG_ENTER,
-                                            self.text[7], self.text_len+7, 64, pynk.ffi.addressof(pynk.lib, "nk_filter_ascii"));
-                    # if (nk_button_label(ctx, "Submit") ||
+                                            self.text[7], self.text_len+7, 64, pynk.ffi.addressof(pynk.lib, "nk_filter_ascii".encode('utf-8')));
+                    # if (nk_button_label(ctx, "Submit".encode('utf-8')) ||
                     #     (active & NK_EDIT_COMMITED))
                     # {
                     #     text[7][text_len[7]] = '\n';
@@ -1168,7 +1168,7 @@ class Overview(object):
                     #     text_len[7] = 0;
                     # }
                     # nk_tree_pop(ctx);
-                    if pynk.lib.nk_button_label(ctx, "Submit") or (active & pynk.lib.NK_EDIT_COMMITED):
+                    if pynk.lib.nk_button_label(ctx, "Submit".encode('utf-8')) or (active & pynk.lib.NK_EDIT_COMMITED):
                         self.text[7][self.text_len[7]] = '\n';
                         self.text_len[7] += 1
                         #TODO: memcpy(&box_buffer[box_len], &text[7], (nk_size)text_len[7]);
@@ -1180,9 +1180,9 @@ class Overview(object):
 
             # }
             #
-            # if (nk_tree_push(ctx, NK_TREE_TAB, "Chart", NK_MINIMIZED))
+            # if (nk_tree_push(ctx, NK_TREE_TAB, "Chart".encode('utf-8'), NK_MINIMIZED))
             # {
-            if self.tree_push(ctx, pynk.lib.NK_TREE_TAB, "Chart", pynk.lib.NK_MINIMIZED, "11"):
+            if self.tree_push(ctx, pynk.lib.NK_TREE_TAB, "Chart".encode('utf-8'), pynk.lib.NK_MINIMIZED, "11".encode('utf-8')):
                 # /* Chart Widgets
                 #  * This library has two different rather simple charts. The line and the
                 #  * column chart. Both provide a simple way of visualizing values and
@@ -1222,7 +1222,7 @@ class Overview(object):
                 # }
                 pynk.lib.nk_layout_row_dynamic(ctx, 100, 1);
                 if pynk.lib.nk_chart_begin(ctx, pynk.lib.NK_CHART_LINES, 32, -1.0, 1.0):
-                    for i in xrange(32):
+                    for i in range(32):
                         res = pynk.lib.nk_chart_push(ctx, math.cos(id))
                         if res & pynk.lib.NK_CHART_HOVERING:
                             index = i
@@ -1232,17 +1232,17 @@ class Overview(object):
                 pynk.lib.nk_chart_end(ctx);
                 #
                 # if (index != -1)
-                #     nk_tooltipf(ctx, "Value: %.2f", (float)cos((float)index*step));
+                #     nk_tooltipf(ctx, "Value: %.2f".encode('utf-8'), (float)cos((float)index*step));
                 # if (line_index != -1) {
                 #     nk_layout_row_dynamic(ctx, 20, 1);
-                #     nk_labelf(ctx, NK_TEXT_LEFT, "Selected value: %.2f", (float)cos((float)index*step));
+                #     nk_labelf(ctx, NK_TEXT_LEFT, "Selected value: %.2f".encode('utf-8'), (float)cos((float)index*step));
                 # }
 
                 if index != -1:
-                    pynk.lib.nk_tooltipf(ctx, "Value: %.2f", pynk.ffi.cast("float", math.cos(index*step)))
+                    pynk.lib.nk_tooltipf(ctx, "Value: %.2f".encode('utf-8'), pynk.ffi.cast("float".encode('utf-8'), math.cos(index*step)))
                 if line_index != -1:
                     pynk.lib.nk_layout_row_dynamic(ctx, 20, 1);
-                    pynk.lib.nk_labelf(ctx, pynk.lib.NK_TEXT_LEFT, "Selected value: %.2f", math.cos(index*step))
+                    pynk.lib.nk_labelf(ctx, pynk.lib.NK_TEXT_LEFT, "Selected value: %.2f".encode('utf-8'), math.cos(index*step))
 
                 # /* column chart */
                 # nk_layout_row_dynamic(ctx, 100, 1);
@@ -1259,15 +1259,15 @@ class Overview(object):
                 #     nk_chart_end(ctx);
                 # }
                 # if (index != -1)
-                #     nk_tooltipf(ctx, "Value: %.2f", (float)fabs(sin(step * (float)index)));
+                #     nk_tooltipf(ctx, "Value: %.2f".encode('utf-8'), (float)fabs(sin(step * (float)index)));
                 # if (col_index != -1) {
                 #     nk_layout_row_dynamic(ctx, 20, 1);
-                #     nk_labelf(ctx, NK_TEXT_LEFT, "Selected value: %.2f", (float)fabs(sin(step * (float)col_index)));
+                #     nk_labelf(ctx, NK_TEXT_LEFT, "Selected value: %.2f".encode('utf-8'), (float)fabs(sin(step * (float)col_index)));
                 # }
                 pynk.lib.nk_layout_row_dynamic(ctx, 100, 1);
                 bounds = pynk.lib.nk_widget_bounds(ctx);
                 if pynk.lib.nk_chart_begin(ctx, pynk.lib.NK_CHART_COLUMN, 32, 0.0, 1.0):
-                    for i in xrange(32):
+                    for i in range(32):
                         res = pynk.lib.nk_chart_push(ctx, math.fabs(math.sin(id)))
                         if res & pynk.lib.NK_CHART_HOVERING:
                             index = i
@@ -1276,10 +1276,10 @@ class Overview(object):
                         id += step;
                     pynk.lib.nk_chart_end(ctx);
                 if index != -1:
-                    pynk.lib.nk_tooltipf(ctx, "Value: %.2f", pynk.ffi.cast("float", math.fabs(math.sin(step * index))))
+                    pynk.lib.nk_tooltipf(ctx, "Value: %.2f".encode('utf-8'), pynk.ffi.cast("float".encode('utf-8'), math.fabs(math.sin(step * index))))
                 if col_index != -1:
                     pynk.lib.nk_layout_row_dynamic(ctx, 20, 1)
-                    pynk.lib.nk_labelf(ctx, pynk.lib.NK_TEXT_LEFT, "Selected value: %.2f", pynk.ffi.cast("float", math.fabs(math.sin(step * col_index))))
+                    pynk.lib.nk_labelf(ctx, pynk.lib.NK_TEXT_LEFT, "Selected value: %.2f".encode('utf-8'), pynk.ffi.cast("float".encode('utf-8'), math.fabs(math.sin(step * col_index))))
                 #
                 # /* mixed chart */
                 # nk_layout_row_dynamic(ctx, 100, 1);
@@ -1301,7 +1301,7 @@ class Overview(object):
                     pynk.lib.nk_chart_add_slot(ctx, pynk.lib.NK_CHART_LINES, 32, -1.0, 1.0)
                     pynk.lib.nk_chart_add_slot(ctx, pynk.lib.NK_CHART_LINES, 32, -1.0, 1.0)
                     id = 0 # TODO: check for previous weird fors like this.
-                    for i in xrange(32):
+                    for i in range(32):
                         pynk.lib.nk_chart_push_slot(ctx, math.fabs(math.sin(id)), 0)
                         pynk.lib.nk_chart_push_slot(ctx, math.cos(id), 1)
                         pynk.lib.nk_chart_push_slot(ctx, math.sin(id), 2)
@@ -1329,7 +1329,7 @@ class Overview(object):
                     pynk.lib.nk_chart_add_slot_colored(ctx, pynk.lib.NK_CHART_LINES, pynk.lib.nk_rgb(0,0,255), pynk.lib.nk_rgb(0,0,150),32, -1.0, 1.0)
                     pynk.lib.nk_chart_add_slot_colored(ctx, pynk.lib.NK_CHART_LINES, pynk.lib.nk_rgb(0,255,0), pynk.lib.nk_rgb(0,150,0), 32, -1.0, 1.0)
                     id = 0
-                    for i in xrange(32):
+                    for i in range(32):
                         pynk.lib.nk_chart_push_slot(ctx, math.fabs(math.sin(id)), 0)
                         pynk.lib.nk_chart_push_slot(ctx, math.cos(id), 1)
                         pynk.lib.nk_chart_push_slot(ctx, math.sin(id), 2)
@@ -1339,64 +1339,64 @@ class Overview(object):
 
             # }
             #
-            # if (nk_tree_push(ctx, NK_TREE_TAB, "Popup", NK_MINIMIZED))
+            # if (nk_tree_push(ctx, NK_TREE_TAB, "Popup".encode('utf-8'), NK_MINIMIZED))
             # {
-            if self.tree_push(ctx, pynk.lib.NK_TREE_TAB, "Popup", pynk.lib.NK_MINIMIZED, "12"):
+            if self.tree_push(ctx, pynk.lib.NK_TREE_TAB, "Popup".encode('utf-8'), pynk.lib.NK_MINIMIZED, "12".encode('utf-8')):
                 # static struct nk_color color = {255,0,0, 255};
                 # static int select[4];
                 # static int popup_active;
                 # const struct nk_input *in = &ctx->input;
                 # struct nk_rect bounds;
-                self.declare("color", [255,0,0, 255], "struct nk_color*")
-                self.declare("select", [0]*4, "int[]")
-                self.declare("popup_active", False)
+                self.declare("color".encode('utf-8'), [255,0,0, 255], "struct nk_color*".encode('utf-8'))
+                self.declare("select".encode('utf-8'), [0]*4, "int[]".encode('utf-8'))
+                self.declare("popup_active".encode('utf-8'), False)
                 bounds = pynk.ffi.new("struct nk_rect*")
 
                 # /* menu contextual */
                 # nk_layout_row_static(ctx, 30, 150, 1);
                 # bounds = nk_widget_bounds(ctx);
-                # nk_label(ctx, "Right click me for menu", NK_TEXT_LEFT);
+                # nk_label(ctx, "Right click me for menu".encode('utf-8'), NK_TEXT_LEFT);
                 #
                 # if (nk_contextual_begin(ctx, 0, nk_vec2(100, 300), bounds)) {
                 #     static size_t prog = 40;
                 #     static int slider = 10;
                 #
                 #     nk_layout_row_dynamic(ctx, 25, 1);
-                #     nk_checkbox_label(ctx, "Menu", &show_menu);
+                #     nk_checkbox_label(ctx, "Menu".encode('utf-8'), &show_menu);
                 #     nk_progress(ctx, &prog, 100, NK_MODIFIABLE);
                 #     nk_slider_int(ctx, 0, &slider, 16, 1);
-                #     if (nk_contextual_item_label(ctx, "About", NK_TEXT_CENTERED))
+                #     if (nk_contextual_item_label(ctx, "About".encode('utf-8'), NK_TEXT_CENTERED))
                 #         show_app_about = nk_true;
-                #     nk_selectable_label(ctx, select[0]?"Unselect":"Select", NK_TEXT_LEFT, &select[0]);
-                #     nk_selectable_label(ctx, select[1]?"Unselect":"Select", NK_TEXT_LEFT, &select[1]);
-                #     nk_selectable_label(ctx, select[2]?"Unselect":"Select", NK_TEXT_LEFT, &select[2]);
-                #     nk_selectable_label(ctx, select[3]?"Unselect":"Select", NK_TEXT_LEFT, &select[3]);
+                #     nk_selectable_label(ctx, select[0]?"Unselect".encode('utf-8'):"Select", NK_TEXT_LEFT, &select[0]);
+                #     nk_selectable_label(ctx, select[1]?"Unselect".encode('utf-8'):"Select", NK_TEXT_LEFT, &select[1]);
+                #     nk_selectable_label(ctx, select[2]?"Unselect".encode('utf-8'):"Select", NK_TEXT_LEFT, &select[2]);
+                #     nk_selectable_label(ctx, select[3]?"Unselect".encode('utf-8'):"Select", NK_TEXT_LEFT, &select[3]);
                 #     nk_contextual_end(ctx);
                 # }
                 pynk.lib.nk_layout_row_static(ctx, 30, 150, 1);
                 bounds = pynk.lib.nk_widget_bounds(ctx);
-                pynk.lib.nk_label(ctx, "Right click me for menu", pynk.lib.NK_TEXT_LEFT);
+                pynk.lib.nk_label(ctx, "Right click me for menu".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
 
                 if pynk.lib.nk_contextual_begin(ctx, 0, pynk.lib.nk_vec2(100, 300), bounds):
-                    self.declare("prog", 40, "unsigned int*")
-                    self.declare("slider", 10, "int*")
+                    self.declare("prog".encode('utf-8'), 40, "unsigned int*".encode('utf-8'))
+                    self.declare("slider".encode('utf-8'), 10, "int*".encode('utf-8'))
 
                     pynk.lib.nk_layout_row_dynamic(ctx, 25, 1)
-                    pynk.lib.nk_checkbox_label(ctx, "Menu", self.show_menu)
+                    pynk.lib.nk_checkbox_label(ctx, "Menu".encode('utf-8'), self.show_menu)
                     pynk.lib.nk_progress(ctx, self.prog, 100, pynk.lib.NK_MODIFIABLE)
                     pynk.lib.nk_slider_int(ctx, 0, self.slider, 16, 1)
-                    if pynk.lib.nk_contextual_item_label(ctx, "About", pynk.lib.NK_TEXT_CENTERED):
+                    if pynk.lib.nk_contextual_item_label(ctx, "About".encode('utf-8'), pynk.lib.NK_TEXT_CENTERED):
                         self.show_app_about[0] = 1
-                    pynk.lib.nk_selectable_label(ctx, "Unselect" if self.select[0] else "Select", pynk.lib.NK_TEXT_LEFT, self.select+0)
-                    pynk.lib.nk_selectable_label(ctx, "Unselect" if self.select[1] else "Select", pynk.lib.NK_TEXT_LEFT, self.select+1);
-                    pynk.lib.nk_selectable_label(ctx, "Unselect" if self.select[2] else "Select", pynk.lib.NK_TEXT_LEFT, self.select+2);
-                    pynk.lib.nk_selectable_label(ctx, "Unselect" if self.select[3] else "Select", pynk.lib.NK_TEXT_LEFT, self.select+3);
+                    pynk.lib.nk_selectable_label(ctx, "Unselect".encode('utf-8') if self.select[0] else "Select".encode('utf-8'), pynk.lib.NK_TEXT_LEFT, self.select+0)
+                    pynk.lib.nk_selectable_label(ctx, "Unselect".encode('utf-8') if self.select[1] else "Select".encode('utf-8'), pynk.lib.NK_TEXT_LEFT, self.select+1);
+                    pynk.lib.nk_selectable_label(ctx, "Unselect".encode('utf-8') if self.select[2] else "Select".encode('utf-8'), pynk.lib.NK_TEXT_LEFT, self.select+2);
+                    pynk.lib.nk_selectable_label(ctx, "Unselect".encode('utf-8') if self.select[3] else "Select".encode('utf-8'), pynk.lib.NK_TEXT_LEFT, self.select+3);
                     pynk.lib.nk_contextual_end(ctx);
 
                 # /* color contextual */
                 # nk_layout_row_begin(ctx, NK_STATIC, 30, 2);
                 # nk_layout_row_push(ctx, 100);
-                # nk_label(ctx, "Right Click here:", NK_TEXT_LEFT);
+                # nk_label(ctx, "Right Click here:".encode('utf-8'), NK_TEXT_LEFT);
                 # nk_layout_row_push(ctx, 50);
                 # bounds = nk_widget_bounds(ctx);
                 # nk_button_color(ctx, color);
@@ -1404,15 +1404,15 @@ class Overview(object):
                 #
                 # if (nk_contextual_begin(ctx, 0, nk_vec2(350, 60), bounds)) {
                 #     nk_layout_row_dynamic(ctx, 30, 4);
-                #     color.r = (nk_byte)nk_propertyi(ctx, "#r", 0, color.r, 255, 1, 1);
-                #     color.g = (nk_byte)nk_propertyi(ctx, "#g", 0, color.g, 255, 1, 1);
-                #     color.b = (nk_byte)nk_propertyi(ctx, "#b", 0, color.b, 255, 1, 1);
-                #     color.a = (nk_byte)nk_propertyi(ctx, "#a", 0, color.a, 255, 1, 1);
+                #     color.r = (nk_byte)nk_propertyi(ctx, "#r".encode('utf-8'), 0, color.r, 255, 1, 1);
+                #     color.g = (nk_byte)nk_propertyi(ctx, "#g".encode('utf-8'), 0, color.g, 255, 1, 1);
+                #     color.b = (nk_byte)nk_propertyi(ctx, "#b".encode('utf-8'), 0, color.b, 255, 1, 1);
+                #     color.a = (nk_byte)nk_propertyi(ctx, "#a".encode('utf-8'), 0, color.a, 255, 1, 1);
                 #     nk_contextual_end(ctx);
                 # }
                 pynk.lib.nk_layout_row_begin(ctx, pynk.lib.NK_STATIC, 30, 2);
                 pynk.lib.nk_layout_row_push(ctx, 100);
-                pynk.lib.nk_label(ctx, "Right Click here:", pynk.lib.NK_TEXT_LEFT);
+                pynk.lib.nk_label(ctx, "Right Click here:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                 pynk.lib.nk_layout_row_push(ctx, 50);
                 bounds = pynk.lib.nk_widget_bounds(ctx);
                 pynk.lib.nk_button_color(ctx, self.color[0]);
@@ -1420,34 +1420,34 @@ class Overview(object):
 
                 if pynk.lib.nk_contextual_begin(ctx, 0, pynk.lib.nk_vec2(350, 60), bounds):
                     pynk.lib.nk_layout_row_dynamic(ctx, 30, 4);
-                    self.color.r = pynk.lib.nk_propertyi(ctx, "#r", 0, self.color.r, 255, 1, 1)
-                    self.color.g = pynk.lib.nk_propertyi(ctx, "#g", 0, self.color.g, 255, 1, 1)
-                    self.color.b = pynk.lib.nk_propertyi(ctx, "#b", 0, self.color.b, 255, 1, 1)
-                    self.color.a = pynk.lib.nk_propertyi(ctx, "#a", 0, self.color.a, 255, 1, 1)
+                    self.color.r = pynk.lib.nk_propertyi(ctx, "#r".encode('utf-8'), 0, self.color.r, 255, 1, 1)
+                    self.color.g = pynk.lib.nk_propertyi(ctx, "#g".encode('utf-8'), 0, self.color.g, 255, 1, 1)
+                    self.color.b = pynk.lib.nk_propertyi(ctx, "#b".encode('utf-8'), 0, self.color.b, 255, 1, 1)
+                    self.color.a = pynk.lib.nk_propertyi(ctx, "#a".encode('utf-8'), 0, self.color.a, 255, 1, 1)
                     pynk.lib.nk_contextual_end(ctx)
                 #
                 # /* popup */
                 # nk_layout_row_begin(ctx, NK_STATIC, 30, 2);
                 # nk_layout_row_push(ctx, 100);
-                # nk_label(ctx, "Popup:", NK_TEXT_LEFT);
+                # nk_label(ctx, "Popup:".encode('utf-8'), NK_TEXT_LEFT);
                 # nk_layout_row_push(ctx, 50);
-                # if (nk_button_label(ctx, "Popup"))
+                # if (nk_button_label(ctx, "Popup".encode('utf-8')))
                 #     popup_active = 1;
                 # nk_layout_row_end(ctx);
                 #
                 # if (popup_active)
                 # {
                 #     static struct nk_rect s = {20, 100, 220, 90};
-                #     if (nk_popup_begin(ctx, NK_POPUP_STATIC, "Error", 0, s))
+                #     if (nk_popup_begin(ctx, NK_POPUP_STATIC, "Error".encode('utf-8'), 0, s))
                 #     {
                 #         nk_layout_row_dynamic(ctx, 25, 1);
-                #         nk_label(ctx, "A terrible error as occured", NK_TEXT_LEFT);
+                #         nk_label(ctx, "A terrible error as occured".encode('utf-8'), NK_TEXT_LEFT);
                 #         nk_layout_row_dynamic(ctx, 25, 2);
-                #         if (nk_button_label(ctx, "OK")) {
+                #         if (nk_button_label(ctx, "OK".encode('utf-8'))) {
                 #             popup_active = 0;
                 #             nk_popup_close(ctx);
                 #         }
-                #         if (nk_button_label(ctx, "Cancel")) {
+                #         if (nk_button_label(ctx, "Cancel".encode('utf-8'))) {
                 #             popup_active = 0;
                 #             nk_popup_close(ctx);
                 #         }
@@ -1456,20 +1456,20 @@ class Overview(object):
                 # }
                 pynk.lib.nk_layout_row_begin(ctx, pynk.lib.NK_STATIC, 30, 2);
                 pynk.lib.nk_layout_row_push(ctx, 100);
-                pynk.lib.nk_label(ctx, "Popup:", pynk.lib.NK_TEXT_LEFT);
+                pynk.lib.nk_label(ctx, "Popup:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                 pynk.lib.nk_layout_row_push(ctx, 50);
-                if pynk.lib.nk_button_label(ctx, "Popup"):
+                if pynk.lib.nk_button_label(ctx, "Popup".encode('utf-8')):
                     self.popup_active = 1;
                 pynk.lib.nk_layout_row_end(ctx);
                 if self.popup_active:
-                    if pynk.lib.nk_popup_begin(ctx, pynk.lib.NK_POPUP_STATIC, "Error", 0, pynk.lib.nk_rect(20, 100, 220, 90)):
+                    if pynk.lib.nk_popup_begin(ctx, pynk.lib.NK_POPUP_STATIC, "Error".encode('utf-8'), 0, pynk.lib.nk_rect(20, 100, 220, 90)):
                         pynk.lib.nk_layout_row_dynamic(ctx, 25, 1);
-                        pynk.lib.nk_label(ctx, "A terrible error as occured", pynk.lib.NK_TEXT_LEFT);
+                        pynk.lib.nk_label(ctx, "A terrible error as occured".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                         pynk.lib.nk_layout_row_dynamic(ctx, 25, 2);
-                        if pynk.lib.nk_button_label(ctx, "OK"):
+                        if pynk.lib.nk_button_label(ctx, "OK".encode('utf-8')):
                             self.popup_active = 0;
                             pynk.lib.nk_popup_close(ctx);
-                        if pynk.lib.nk_button_label(ctx, "Cancel"):
+                        if pynk.lib.nk_button_label(ctx, "Cancel".encode('utf-8')):
                             self.popup_active = 0;
                             pynk.lib.nk_popup_close(ctx);
                         pynk.lib.nk_popup_end(ctx);
@@ -1478,190 +1478,190 @@ class Overview(object):
                 # /* tooltip */
                 # nk_layout_row_static(ctx, 30, 150, 1);
                 # bounds = nk_widget_bounds(ctx);
-                # nk_label(ctx, "Hover me for tooltip", NK_TEXT_LEFT);
+                # nk_label(ctx, "Hover me for tooltip".encode('utf-8'), NK_TEXT_LEFT);
                 # if (nk_input_is_mouse_hovering_rect(in, bounds))
-                #     nk_tooltip(ctx, "This is a tooltip");
+                #     nk_tooltip(ctx, "This is a tooltip".encode('utf-8'));
                 #
                 # nk_tree_pop(ctx);
                 pynk.lib.nk_layout_row_static(ctx, 30, 150, 1);
                 bounds = pynk.lib.nk_widget_bounds(ctx);
-                pynk.lib.nk_label(ctx, "Hover me for tooltip", pynk.lib.NK_TEXT_LEFT);
-                inp = pynk.ffi.addressof(ctx, "input")
+                pynk.lib.nk_label(ctx, "Hover me for tooltip".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
+                inp = pynk.ffi.addressof(ctx, "input".encode('utf-8'))
                 if pynk.lib.nk_input_is_mouse_hovering_rect(inp, bounds):
-                    pynk.lib.nk_tooltip(ctx, "This is a tooltip");
+                    pynk.lib.nk_tooltip(ctx, "This is a tooltip".encode('utf-8'));
 
                 pynk.lib.nk_tree_pop(ctx);
             # }
             #
-            # if (nk_tree_push(ctx, NK_TREE_TAB, "Layout", NK_MINIMIZED))
+            # if (nk_tree_push(ctx, NK_TREE_TAB, "Layout".encode('utf-8'), NK_MINIMIZED))
             # {
-            if self.tree_push(ctx, pynk.lib.NK_TREE_TAB, "Layout", pynk.lib.NK_MINIMIZED, "13"):
-                # if (nk_tree_push(ctx, NK_TREE_NODE, "Widget", NK_MINIMIZED))
+            if self.tree_push(ctx, pynk.lib.NK_TREE_TAB, "Layout".encode('utf-8'), pynk.lib.NK_MINIMIZED, "13".encode('utf-8')):
+                # if (nk_tree_push(ctx, NK_TREE_NODE, "Widget".encode('utf-8'), NK_MINIMIZED))
                 # {
-                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Widget", pynk.lib.NK_MINIMIZED, "14"):
+                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Widget".encode('utf-8'), pynk.lib.NK_MINIMIZED, "14".encode('utf-8')):
                     # float ratio_two[] = {0.2f, 0.6f, 0.2f};
                     # float width_two[] = {100, 200, 50};
                     ratio_two = pynk.ffi.new("float[]", [0.2, 0.6, 0.2])
                     width_two = pynk.ffi.new("float[]", [100, 200, 50])
                     #
                     # nk_layout_row_dynamic(ctx, 30, 1);
-                    # nk_label(ctx, "Dynamic fixed column layout with generated position and size:", NK_TEXT_LEFT);
+                    # nk_label(ctx, "Dynamic fixed column layout with generated position and size:".encode('utf-8'), NK_TEXT_LEFT);
                     # nk_layout_row_dynamic(ctx, 30, 3);
-                    # nk_button_label(ctx, "button");
-                    # nk_button_label(ctx, "button");
-                    # nk_button_label(ctx, "button");
+                    # nk_button_label(ctx, "button".encode('utf-8'));
+                    # nk_button_label(ctx, "button".encode('utf-8'));
+                    # nk_button_label(ctx, "button".encode('utf-8'));
                     pynk.lib.nk_layout_row_dynamic(ctx, 30, 1);
-                    pynk.lib.nk_label(ctx, "Dynamic fixed column layout with generated position and size:", pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_label(ctx, "Dynamic fixed column layout with generated position and size:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                     pynk.lib.nk_layout_row_dynamic(ctx, 30, 3);
-                    pynk.lib.nk_button_label(ctx, "button");
-                    pynk.lib.nk_button_label(ctx, "button");
-                    pynk.lib.nk_button_label(ctx, "button");
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
                     #
                     # nk_layout_row_dynamic(ctx, 30, 1);
-                    # nk_label(ctx, "static fixed column layout with generated position and size:", NK_TEXT_LEFT);
+                    # nk_label(ctx, "static fixed column layout with generated position and size:".encode('utf-8'), NK_TEXT_LEFT);
                     # nk_layout_row_static(ctx, 30, 100, 3);
-                    # nk_button_label(ctx, "button");
-                    # nk_button_label(ctx, "button");
-                    # nk_button_label(ctx, "button");
+                    # nk_button_label(ctx, "button".encode('utf-8'));
+                    # nk_button_label(ctx, "button".encode('utf-8'));
+                    # nk_button_label(ctx, "button".encode('utf-8'));
                     pynk.lib.nk_layout_row_dynamic(ctx, 30, 1);
-                    pynk.lib.nk_label(ctx, "static fixed column layout with generated position and size:", pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_label(ctx, "static fixed column layout with generated position and size:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                     pynk.lib.nk_layout_row_static(ctx, 30, 100, 3);
-                    pynk.lib.nk_button_label(ctx, "button");
-                    pynk.lib.nk_button_label(ctx, "button");
-                    pynk.lib.nk_button_label(ctx, "button");
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
                     #
                     # nk_layout_row_dynamic(ctx, 30, 1);
-                    # nk_label(ctx, "Dynamic array-based custom column layout with generated position and custom size:",NK_TEXT_LEFT);
+                    # nk_label(ctx, "Dynamic array-based custom column layout with generated position and custom size:".encode('utf-8'),NK_TEXT_LEFT);
                     # nk_layout_row(ctx, NK_DYNAMIC, 30, 3, ratio_two);
-                    # nk_button_label(ctx, "button");
-                    # nk_button_label(ctx, "button");
-                    # nk_button_label(ctx, "button");
+                    # nk_button_label(ctx, "button".encode('utf-8'));
+                    # nk_button_label(ctx, "button".encode('utf-8'));
+                    # nk_button_label(ctx, "button".encode('utf-8'));
                     pynk.lib.nk_layout_row_dynamic(ctx, 30, 1);
-                    pynk.lib.nk_label(ctx, "Dynamic array-based custom column layout with generated position and custom size:",pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_label(ctx, "Dynamic array-based custom column layout with generated position and custom size:".encode('utf-8'),pynk.lib.NK_TEXT_LEFT);
                     pynk.lib.nk_layout_row(ctx, pynk.lib.NK_DYNAMIC, 30, 3, ratio_two);
-                    pynk.lib.nk_button_label(ctx, "button");
-                    pynk.lib.nk_button_label(ctx, "button");
-                    pynk.lib.nk_button_label(ctx, "button");
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
                     #
                     # nk_layout_row_dynamic(ctx, 30, 1);
-                    # nk_label(ctx, "Static array-based custom column layout with generated position and custom size:",NK_TEXT_LEFT );
+                    # nk_label(ctx, "Static array-based custom column layout with generated position and custom size:".encode('utf-8'),NK_TEXT_LEFT );
                     # nk_layout_row(ctx, NK_STATIC, 30, 3, width_two);
-                    # nk_button_label(ctx, "button");
-                    # nk_button_label(ctx, "button");
-                    # nk_button_label(ctx, "button");
+                    # nk_button_label(ctx, "button".encode('utf-8'));
+                    # nk_button_label(ctx, "button".encode('utf-8'));
+                    # nk_button_label(ctx, "button".encode('utf-8'));
                     pynk.lib.nk_layout_row_dynamic(ctx, 30, 1);
-                    pynk.lib.nk_label(ctx, "Static array-based custom column layout with generated position and custom size:",pynk.lib.NK_TEXT_LEFT );
+                    pynk.lib.nk_label(ctx, "Static array-based custom column layout with generated position and custom size:".encode('utf-8'),pynk.lib.NK_TEXT_LEFT );
                     pynk.lib.nk_layout_row(ctx, pynk.lib.NK_STATIC, 30, 3, width_two);
-                    pynk.lib.nk_button_label(ctx, "button");
-                    pynk.lib.nk_button_label(ctx, "button");
-                    pynk.lib.nk_button_label(ctx, "button");
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
                     #
                     # nk_layout_row_dynamic(ctx, 30, 1);
-                    # nk_label(ctx, "Dynamic immediate mode custom column layout with generated position and custom size:",NK_TEXT_LEFT);
+                    # nk_label(ctx, "Dynamic immediate mode custom column layout with generated position and custom size:".encode('utf-8'),NK_TEXT_LEFT);
                     # nk_layout_row_begin(ctx, NK_DYNAMIC, 30, 3);
                     # nk_layout_row_push(ctx, 0.2f);
-                    # nk_button_label(ctx, "button");
+                    # nk_button_label(ctx, "button".encode('utf-8'));
                     # nk_layout_row_push(ctx, 0.6f);
-                    # nk_button_label(ctx, "button");
+                    # nk_button_label(ctx, "button".encode('utf-8'));
                     # nk_layout_row_push(ctx, 0.2f);
-                    # nk_button_label(ctx, "button");
+                    # nk_button_label(ctx, "button".encode('utf-8'));
                     # nk_layout_row_end(ctx);
                     pynk.lib.nk_layout_row_dynamic(ctx, 30, 1);
-                    pynk.lib.nk_label(ctx, "Dynamic immediate mode custom column layout with generated position and custom size:",pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_label(ctx, "Dynamic immediate mode custom column layout with generated position and custom size:".encode('utf-8'),pynk.lib.NK_TEXT_LEFT);
                     pynk.lib.nk_layout_row_begin(ctx, pynk.lib.NK_DYNAMIC, 30, 3);
                     pynk.lib.nk_layout_row_push(ctx, 0.2);
-                    pynk.lib.nk_button_label(ctx, "button");
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
                     pynk.lib.nk_layout_row_push(ctx, 0.6);
-                    pynk.lib.nk_button_label(ctx, "button");
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
                     pynk.lib.nk_layout_row_push(ctx, 0.2);
-                    pynk.lib.nk_button_label(ctx, "button");
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
                     pynk.lib.nk_layout_row_end(ctx);
                     #
                     # nk_layout_row_dynamic(ctx, 30, 1);
-                    # nk_label(ctx, "Static immediate mode custom column layout with generated position and custom size:", NK_TEXT_LEFT);
+                    # nk_label(ctx, "Static immediate mode custom column layout with generated position and custom size:".encode('utf-8'), NK_TEXT_LEFT);
                     # nk_layout_row_begin(ctx, NK_STATIC, 30, 3);
                     # nk_layout_row_push(ctx, 100);
-                    # nk_button_label(ctx, "button");
+                    # nk_button_label(ctx, "button".encode('utf-8'));
                     # nk_layout_row_push(ctx, 200);
-                    # nk_button_label(ctx, "button");
+                    # nk_button_label(ctx, "button".encode('utf-8'));
                     # nk_layout_row_push(ctx, 50);
-                    # nk_button_label(ctx, "button");
+                    # nk_button_label(ctx, "button".encode('utf-8'));
                     # nk_layout_row_end(ctx);
                     #
                     pynk.lib.nk_layout_row_dynamic(ctx, 30, 1);
-                    pynk.lib.nk_label(ctx, "Static immediate mode custom column layout with generated position and custom size:", pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_label(ctx, "Static immediate mode custom column layout with generated position and custom size:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                     pynk.lib.nk_layout_row_begin(ctx, pynk.lib.NK_STATIC, 30, 3);
                     pynk.lib.nk_layout_row_push(ctx, 100);
-                    pynk.lib.nk_button_label(ctx, "button");
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
                     pynk.lib.nk_layout_row_push(ctx, 200);
-                    pynk.lib.nk_button_label(ctx, "button");
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
                     pynk.lib.nk_layout_row_push(ctx, 50);
-                    pynk.lib.nk_button_label(ctx, "button");
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
                     pynk.lib.nk_layout_row_end(ctx);
                     #
                     # nk_layout_row_dynamic(ctx, 30, 1);
-                    # nk_label(ctx, "Static free space with custom position and custom size:", NK_TEXT_LEFT);
+                    # nk_label(ctx, "Static free space with custom position and custom size:".encode('utf-8'), NK_TEXT_LEFT);
                     # nk_layout_space_begin(ctx, NK_STATIC, 60, 4);
                     # nk_layout_space_push(ctx, nk_rect(100, 0, 100, 30));
-                    # nk_button_label(ctx, "button");
+                    # nk_button_label(ctx, "button".encode('utf-8'));
                     # nk_layout_space_push(ctx, nk_rect(0, 15, 100, 30));
-                    # nk_button_label(ctx, "button");
+                    # nk_button_label(ctx, "button".encode('utf-8'));
                     # nk_layout_space_push(ctx, nk_rect(200, 15, 100, 30));
-                    # nk_button_label(ctx, "button");
+                    # nk_button_label(ctx, "button".encode('utf-8'));
                     # nk_layout_space_push(ctx, nk_rect(100, 30, 100, 30));
-                    # nk_button_label(ctx, "button");
+                    # nk_button_label(ctx, "button".encode('utf-8'));
                     # nk_layout_space_end(ctx);
                     pynk.lib.nk_layout_row_dynamic(ctx, 30, 1);
-                    pynk.lib.nk_label(ctx, "Static free space with custom position and custom size:", pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_label(ctx, "Static free space with custom position and custom size:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                     pynk.lib.nk_layout_space_begin(ctx, pynk.lib.NK_STATIC, 60, 4);
                     pynk.lib.nk_layout_space_push(ctx, pynk.lib.nk_rect(100, 0, 100, 30));
-                    pynk.lib.nk_button_label(ctx, "button");
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
                     pynk.lib.nk_layout_space_push(ctx, pynk.lib.nk_rect(0, 15, 100, 30));
-                    pynk.lib.nk_button_label(ctx, "button");
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
                     pynk.lib.nk_layout_space_push(ctx, pynk.lib.nk_rect(200, 15, 100, 30));
-                    pynk.lib.nk_button_label(ctx, "button");
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
                     pynk.lib.nk_layout_space_push(ctx, pynk.lib.nk_rect(100, 30, 100, 30));
-                    pynk.lib.nk_button_label(ctx, "button");
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
                     pynk.lib.nk_layout_space_end(ctx);
                     #
                     # nk_layout_row_dynamic(ctx, 30, 1);
-                    # nk_label(ctx, "Row template:", NK_TEXT_LEFT);
+                    # nk_label(ctx, "Row template:".encode('utf-8'), NK_TEXT_LEFT);
                     # nk_layout_row_template_begin(ctx, 30);
                     # nk_layout_row_template_push_dynamic(ctx);
                     # nk_layout_row_template_push_variable(ctx, 80);
                     # nk_layout_row_template_push_static(ctx, 80);
                     # nk_layout_row_template_end(ctx);
-                    # nk_button_label(ctx, "button");
-                    # nk_button_label(ctx, "button");
-                    # nk_button_label(ctx, "button");
+                    # nk_button_label(ctx, "button".encode('utf-8'));
+                    # nk_button_label(ctx, "button".encode('utf-8'));
+                    # nk_button_label(ctx, "button".encode('utf-8'));
                     pynk.lib.nk_layout_row_dynamic(ctx, 30, 1);
-                    pynk.lib.nk_label(ctx, "Row template:", pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_label(ctx, "Row template:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                     pynk.lib.nk_layout_row_template_begin(ctx, 30);
                     pynk.lib.nk_layout_row_template_push_dynamic(ctx);
                     pynk.lib.nk_layout_row_template_push_variable(ctx, 80);
                     pynk.lib.nk_layout_row_template_push_static(ctx, 80);
                     pynk.lib.nk_layout_row_template_end(ctx);
-                    pynk.lib.nk_button_label(ctx, "button");
-                    pynk.lib.nk_button_label(ctx, "button");
-                    pynk.lib.nk_button_label(ctx, "button");
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
+                    pynk.lib.nk_button_label(ctx, "button".encode('utf-8'));
                     #
                     # nk_tree_pop(ctx);
                     pynk.lib.nk_tree_pop(ctx);
                 # }
                 #
-                # if (nk_tree_push(ctx, NK_TREE_NODE, "Group", NK_MINIMIZED))
+                # if (nk_tree_push(ctx, NK_TREE_NODE, "Group".encode('utf-8'), NK_MINIMIZED))
                 # {
-                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Group", pynk.lib.NK_MINIMIZED, "15"):
+                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Group".encode('utf-8'), pynk.lib.NK_MINIMIZED, "15".encode('utf-8')):
                     # static int group_titlebar = nk_false;
                     # static int group_border = nk_true;
                     # static int group_no_scrollbar = nk_false;
                     # static int group_width = 320;
                     # static int group_height = 200;
-                    self.declare("group_titlebar", 0, "int*")
-                    self.declare("group_border", 1, "int*")
-                    self.declare("group_no_scrollbar", 0, "int*")
-                    self.declare("group_width", 320, "int*")
-                    self.declare("group_height", 200, "int*")
+                    self.declare("group_titlebar".encode('utf-8'), 0, "int*".encode('utf-8'))
+                    self.declare("group_border".encode('utf-8'), 1, "int*".encode('utf-8'))
+                    self.declare("group_no_scrollbar".encode('utf-8'), 0, "int*".encode('utf-8'))
+                    self.declare("group_width".encode('utf-8'), 320, "int*".encode('utf-8'))
+                    self.declare("group_height".encode('utf-8'), 200, "int*".encode('utf-8'))
                     #
                     # nk_flags group_flags = 0;
                     # if (group_border) group_flags |= NK_WINDOW_BORDER;
@@ -1673,71 +1673,71 @@ class Overview(object):
                     if self.group_titlebar[0]: group_flags |= pynk.lib.NK_WINDOW_TITLE;
                     #
                     # nk_layout_row_dynamic(ctx, 30, 3);
-                    # nk_checkbox_label(ctx, "Titlebar", &group_titlebar);
-                    # nk_checkbox_label(ctx, "Border", &group_border);
-                    # nk_checkbox_label(ctx, "No Scrollbar", &group_no_scrollbar);
+                    # nk_checkbox_label(ctx, "Titlebar".encode('utf-8'), &group_titlebar);
+                    # nk_checkbox_label(ctx, "Border".encode('utf-8'), &group_border);
+                    # nk_checkbox_label(ctx, "No Scrollbar".encode('utf-8'), &group_no_scrollbar);
                     pynk.lib.nk_layout_row_dynamic(ctx, 30, 3);
-                    pynk.lib.nk_checkbox_label(ctx, "Titlebar", self.group_titlebar);
-                    pynk.lib.nk_checkbox_label(ctx, "Border", self.group_border);
-                    pynk.lib.nk_checkbox_label(ctx, "No Scrollbar", self.group_no_scrollbar);
+                    pynk.lib.nk_checkbox_label(ctx, "Titlebar".encode('utf-8'), self.group_titlebar);
+                    pynk.lib.nk_checkbox_label(ctx, "Border".encode('utf-8'), self.group_border);
+                    pynk.lib.nk_checkbox_label(ctx, "No Scrollbar".encode('utf-8'), self.group_no_scrollbar);
                     #
                     # nk_layout_row_begin(ctx, NK_STATIC, 22, 3);
                     # nk_layout_row_push(ctx, 50);
-                    # nk_label(ctx, "size:", NK_TEXT_LEFT);
+                    # nk_label(ctx, "size:".encode('utf-8'), NK_TEXT_LEFT);
                     # nk_layout_row_push(ctx, 130);
-                    # nk_property_int(ctx, "#Width:", 100, &group_width, 500, 10, 1);
+                    # nk_property_int(ctx, "#Width:".encode('utf-8'), 100, &group_width, 500, 10, 1);
                     # nk_layout_row_push(ctx, 130);
-                    # nk_property_int(ctx, "#Height:", 100, &group_height, 500, 10, 1);
+                    # nk_property_int(ctx, "#Height:".encode('utf-8'), 100, &group_height, 500, 10, 1);
                     # nk_layout_row_end(ctx);
                     pynk.lib.nk_layout_row_begin(ctx, pynk.lib.NK_STATIC, 22, 3);
                     pynk.lib.nk_layout_row_push(ctx, 50);
-                    pynk.lib.nk_label(ctx, "size:", pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_label(ctx, "size:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                     pynk.lib.nk_layout_row_push(ctx, 130);
-                    pynk.lib.nk_property_int(ctx, "#Width:", 100, self.group_width, 500, 10, 1);
+                    pynk.lib.nk_property_int(ctx, "#Width:".encode('utf-8'), 100, self.group_width, 500, 10, 1);
                     pynk.lib.nk_layout_row_push(ctx, 130);
-                    pynk.lib.nk_property_int(ctx, "#Height:", 100, self.group_height, 500, 10, 1);
+                    pynk.lib.nk_property_int(ctx, "#Height:".encode('utf-8'), 100, self.group_height, 500, 10, 1);
                     pynk.lib.nk_layout_row_end(ctx);
                     #
                     # nk_layout_row_static(ctx, (float)group_height, group_width, 2);
-                    # if (nk_group_begin(ctx, "Group", group_flags)) {
+                    # if (nk_group_begin(ctx, "Group".encode('utf-8'), group_flags)) {
                     #     int i = 0;
                     #     static int selected[16];
                     #     nk_layout_row_static(ctx, 18, 100, 1);
                     #     for (i = 0; i < 16; ++i)
-                    #         nk_selectable_label(ctx, (selected[i]) ? "Selected": "Unselected", NK_TEXT_CENTERED, &selected[i]);
+                    #         nk_selectable_label(ctx, (selected[i]) ? "Selected".encode('utf-8'): "Unselected".encode('utf-8'), NK_TEXT_CENTERED, &selected[i]);
                     #     nk_group_end(ctx);
                     # }
                     # nk_tree_pop(ctx);
 
                     pynk.lib.nk_layout_row_static(ctx, self.group_height[0], self.group_width[0], 2);
-                    if pynk.lib.nk_group_begin(ctx, "Group", group_flags):
-                        self.declare("selected", [0]*16, "int[]")
+                    if pynk.lib.nk_group_begin(ctx, "Group".encode('utf-8'), group_flags):
+                        self.declare("selected".encode('utf-8'), [0]*16, "int[]".encode('utf-8'))
                         pynk.lib.nk_layout_row_static(ctx, 18, 100, 1);
-                        for i in xrange(16):
-                            pynk.lib.nk_selectable_label(ctx, "Selected" if (self.selected[i]) else "Unselected", pynk.lib.NK_TEXT_CENTERED, self.selected+i);
+                        for i in range(16):
+                            pynk.lib.nk_selectable_label(ctx, "Selected".encode('utf-8') if (self.selected[i]) else "Unselected".encode('utf-8'), pynk.lib.NK_TEXT_CENTERED, self.selected+i);
                         pynk.lib.nk_group_end(ctx);
                     pynk.lib.nk_tree_pop(ctx);
                 # }
                 #
-                # if (nk_tree_push(ctx, NK_TREE_NODE, "Notebook", NK_MINIMIZED))
+                # if (nk_tree_push(ctx, NK_TREE_NODE, "Notebook".encode('utf-8'), NK_MINIMIZED))
                 # {
-                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Notebook", pynk.lib.NK_MINIMIZED, "16"):
+                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Notebook".encode('utf-8'), pynk.lib.NK_MINIMIZED, "16".encode('utf-8')):
                     # static int current_tab = 0;
                     # struct nk_vec2 item_padding;
                     # struct nk_rect bounds;
                     # float step = (2*3.141592654f) / 32;
                     # enum chart_type {CHART_LINE, CHART_HISTO, CHART_MIXED};
-                    # const char *names[] = {"Lines", "Columns", "Mixed"};
+                    # const char *names[] = {"Lines".encode('utf-8'), "Columns".encode('utf-8'), "Mixed".encode('utf-8')};
                     # float id = 0;
                     # int i;
-                    self.declare("current_tab", 0, "int*")
+                    self.declare("current_tab".encode('utf-8'), 0, "int*".encode('utf-8'))
                     item_padding = pynk.ffi.new("struct nk_vec2*")
                     bounds = pynk.ffi.new("struct nk_rect*")
                     step = (2*3.141592654) / 32
                     CHART_LINE = 0
                     CHART_HISTO = 1
                     CHART_MIXED = 2
-                    names = ["Lines", "Columns", "Mixed"]
+                    names = ["Lines".encode('utf-8'), "Columns".encode('utf-8'), "Mixed".encode('utf-8')]
                     id = 0
 
                     #
@@ -1760,10 +1760,10 @@ class Overview(object):
                     #     } else current_tab = nk_button_label(ctx, names[i]) ? i: current_tab;
                     # }
                     # nk_style_pop_float(ctx);
-                    pynk.lib.nk_style_push_vec2(ctx, self.get_field_cdata(ctx, "style.window.spacing"), pynk.lib.nk_vec2(0,0));
-                    pynk.lib.nk_style_push_float(ctx, self.get_field_cdata(ctx, "style.button.rounding"), 0);
+                    pynk.lib.nk_style_push_vec2(ctx, self.get_field_cdata(ctx, "style.window.spacing".encode('utf-8')), pynk.lib.nk_vec2(0,0));
+                    pynk.lib.nk_style_push_float(ctx, self.get_field_cdata(ctx, "style.button.rounding".encode('utf-8')), 0);
                     pynk.lib.nk_layout_row_begin(ctx, pynk.lib.NK_STATIC, 20, 3);
-                    for i in xrange(3):
+                    for i in range(3):
                         #/* make sure button perfectly fits text */
                         f = ctx.style.font;
                         # TODO: cffi does not support passing unions by value so this won't work at present.
@@ -1782,7 +1782,7 @@ class Overview(object):
                     #
                     # /* Body */
                     # nk_layout_row_dynamic(ctx, 140, 1);
-                    # if (nk_group_begin(ctx, "Notebook", NK_WINDOW_BORDER))
+                    # if (nk_group_begin(ctx, "Notebook".encode('utf-8'), NK_WINDOW_BORDER))
                     # {
                     #     nk_style_pop_vec2(ctx);
                     #     switch (current_tab) {
@@ -1830,7 +1830,7 @@ class Overview(object):
                     # } else nk_style_pop_vec2(ctx);
                     # nk_tree_pop(ctx);
                     pynk.lib.nk_layout_row_dynamic(ctx, 140, 1);
-                    if pynk.lib.nk_group_begin(ctx, "Notebook", pynk.lib.NK_WINDOW_BORDER):
+                    if pynk.lib.nk_group_begin(ctx, "Notebook".encode('utf-8'), pynk.lib.NK_WINDOW_BORDER):
                         pynk.lib.nk_style_pop_vec2(ctx);
                         if self.current_tab[0] == CHART_LINE:
                             pynk.lib.nk_layout_row_dynamic(ctx, 100, 1);
@@ -1838,7 +1838,7 @@ class Overview(object):
                             if pynk.lib.nk_chart_begin_colored(ctx, pynk.lib.NK_CHART_LINES, pynk.lib.nk_rgb(255,0,0), pynk.lib.nk_rgb(150,0,0), 32, 0.0, 1.0):
                                 pynk.lib.nk_chart_add_slot_colored(ctx, pynk.lib.NK_CHART_LINES, pynk.lib.nk_rgb(0,0,255), pynk.lib.nk_rgb(0,0,150),32, -1.0, 1.0);
                                 id = 0
-                                for i in xrange(32):
+                                for i in range(32):
                                     pynk.lib.nk_chart_push_slot(ctx, math.fabs(math.sin(id)), 0);
                                     pynk.lib.nk_chart_push_slot(ctx, math.cos(id), 1);
                                     id += step;
@@ -1848,7 +1848,7 @@ class Overview(object):
                             bounds = pynk.lib.nk_widget_bounds(ctx);
                             if pynk.lib.nk_chart_begin_colored(ctx, pynk.lib.NK_CHART_COLUMN, pynk.lib.nk_rgb(255,0,0), pynk.lib.nk_rgb(150,0,0), 32, 0.0, 1.0):
                                 id = 0
-                                for i in xrange(32):
+                                for i in range(32):
                                     pynk.lib.nk_chart_push_slot(ctx, math.fabs(math.sin(id)), 0);
                                     id += step;
                                 pynk.lib.nk_chart_end(ctx);
@@ -1859,7 +1859,7 @@ class Overview(object):
                                 pynk.lib.nk_chart_add_slot_colored(ctx, pynk.lib.NK_CHART_LINES, pynk.lib.nk_rgb(0,0,255), pynk.lib.nk_rgb(0,0,150),32, -1.0, 1.0);
                                 pynk.lib.nk_chart_add_slot_colored(ctx, pynk.lib.NK_CHART_COLUMN, pynk.lib.nk_rgb(0,255,0), pynk.lib.nk_rgb(0,150,0), 32, 0.0, 1.0);
                                 id = 0
-                                for i in xrange(32):
+                                for i in range(32):
                                     pynk.lib.nk_chart_push_slot(ctx, math.fabs(math.sin(id)), 0);
                                     pynk.lib.nk_chart_push_slot(ctx, math.fabs(math.cos(id)), 1);
                                     pynk.lib.nk_chart_push_slot(ctx, math.fabs(math.sin(id)), 2);
@@ -1871,182 +1871,182 @@ class Overview(object):
                     pynk.lib.nk_tree_pop(ctx);
                 # }
                 #
-                # if (nk_tree_push(ctx, NK_TREE_NODE, "Simple", NK_MINIMIZED))
+                # if (nk_tree_push(ctx, NK_TREE_NODE, "Simple".encode('utf-8'), NK_MINIMIZED))
                 # {
-                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Simple", pynk.lib.NK_MINIMIZED, "17"):
+                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Simple".encode('utf-8'), pynk.lib.NK_MINIMIZED, "17".encode('utf-8')):
                     # nk_layout_row_dynamic(ctx, 300, 2);
-                    # if (nk_group_begin(ctx, "Group_Without_Border", 0)) {
+                    # if (nk_group_begin(ctx, "Group_Without_Border".encode('utf-8'), 0)) {
                     #     int i = 0;
                     #     char buffer[64];
                     #     nk_layout_row_static(ctx, 18, 150, 1);
                     #     for (i = 0; i < 64; ++i) {
-                    #         sprintf(buffer, "0x%02x", i);
-                    #         nk_labelf(ctx, NK_TEXT_LEFT, "%s: scrollable region", buffer);
+                    #         sprintf(buffer, "0x%02x".encode('utf-8'), i);
+                    #         nk_labelf(ctx, NK_TEXT_LEFT, "%s: scrollable region".encode('utf-8'), buffer);
                     #     }
                     #     nk_group_end(ctx);
                     # }
-                    # if (nk_group_begin(ctx, "Group_With_Border", NK_WINDOW_BORDER)) {
+                    # if (nk_group_begin(ctx, "Group_With_Border".encode('utf-8'), NK_WINDOW_BORDER)) {
                     #     int i = 0;
                     #     char buffer[64];
                     #     nk_layout_row_dynamic(ctx, 25, 2);
                     #     for (i = 0; i < 64; ++i) {
-                    #         sprintf(buffer, "%08d", ((((i%7)*10)^32))+(64+(i%2)*2));
+                    #         sprintf(buffer, "%08d".encode('utf-8'), ((((i%7)*10)^32))+(64+(i%2)*2));
                     #         nk_button_label(ctx, buffer);
                     #     }
                     #     nk_group_end(ctx);
                     # }
                     # nk_tree_pop(ctx);
                     pynk.lib.nk_layout_row_dynamic(ctx, 300, 2);
-                    if pynk.lib.nk_group_begin(ctx, "Group_Without_Border", 0):
+                    if pynk.lib.nk_group_begin(ctx, "Group_Without_Border".encode('utf-8'), 0):
                         pynk.lib.nk_layout_row_static(ctx, 18, 150, 1);
-                        for i in xrange(64):
-                            pynk.lib.nk_labelf(ctx, pynk.lib.NK_TEXT_LEFT, "%s: scrollable region" % str(i));
+                        for i in range(64):
+                            pynk.lib.nk_labelf(ctx, pynk.lib.NK_TEXT_LEFT, "%s: scrollable region".encode('utf-8') % str(i));
                         pynk.lib.nk_group_end(ctx);
-                    if pynk.lib.nk_group_begin(ctx, "Group_With_Border", pynk.lib.NK_WINDOW_BORDER):
+                    if pynk.lib.nk_group_begin(ctx, "Group_With_Border".encode('utf-8'), pynk.lib.NK_WINDOW_BORDER):
                         pynk.lib.nk_layout_row_dynamic(ctx, 25, 2);
-                        for i in xrange(64):
+                        for i in range(64):
                             pynk.lib.nk_button_label(ctx, str(((((i%7)*10)^32))+(64+(i%2)*2)));
                         pynk.lib.nk_group_end(ctx);
                     pynk.lib.nk_tree_pop(ctx);
                 # }
                 #
-                # if (nk_tree_push(ctx, NK_TREE_NODE, "Complex", NK_MINIMIZED))
+                # if (nk_tree_push(ctx, NK_TREE_NODE, "Complex".encode('utf-8'), NK_MINIMIZED))
                 # {
-                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Complex", pynk.lib.NK_MINIMIZED, "18"):
+                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Complex".encode('utf-8'), pynk.lib.NK_MINIMIZED, "18".encode('utf-8')):
                     # int i;
                     # nk_layout_space_begin(ctx, NK_STATIC, 500, 64);
                     # nk_layout_space_push(ctx, nk_rect(0,0,150,500));
-                    # if (nk_group_begin(ctx, "Group_left", NK_WINDOW_BORDER)) {
+                    # if (nk_group_begin(ctx, "Group_left".encode('utf-8'), NK_WINDOW_BORDER)) {
                     #     static int selected[32];
                     #     nk_layout_row_static(ctx, 18, 100, 1);
                     #     for (i = 0; i < 32; ++i)
-                    #         nk_selectable_label(ctx, (selected[i]) ? "Selected": "Unselected", NK_TEXT_CENTERED, &selected[i]);
+                    #         nk_selectable_label(ctx, (selected[i]) ? "Selected".encode('utf-8'): "Unselected".encode('utf-8'), NK_TEXT_CENTERED, &selected[i]);
                     #     nk_group_end(ctx);
                     # }
                     pynk.lib.nk_layout_space_begin(ctx, pynk.lib.NK_STATIC, 500, 64);
                     pynk.lib.nk_layout_space_push(ctx, pynk.lib.nk_rect(0,0,150,500));
-                    if pynk.lib.nk_group_begin(ctx, "Group_left", pynk.lib.NK_WINDOW_BORDER):
-                        self.declare("selected", [0]*32, "int[]")
+                    if pynk.lib.nk_group_begin(ctx, "Group_left".encode('utf-8'), pynk.lib.NK_WINDOW_BORDER):
+                        self.declare("selected".encode('utf-8'), [0]*32, "int[]".encode('utf-8'))
                         pynk.lib.nk_layout_row_static(ctx, 18, 100, 1);
-                        for i in xrange(32):
-                            pynk.lib.nk_selectable_label(ctx, "Selected" if self.selected[i] else "Unselected", pynk.lib.NK_TEXT_CENTERED, self.selected+i);
+                        for i in range(32):
+                            pynk.lib.nk_selectable_label(ctx, "Selected".encode('utf-8') if self.selected[i] else "Unselected".encode('utf-8'), pynk.lib.NK_TEXT_CENTERED, self.selected+i);
                         pynk.lib.nk_group_end(ctx);
                     #
                     # nk_layout_space_push(ctx, nk_rect(160,0,150,240));
-                    # if (nk_group_begin(ctx, "Group_top", NK_WINDOW_BORDER)) {
+                    # if (nk_group_begin(ctx, "Group_top".encode('utf-8'), NK_WINDOW_BORDER)) {
                     #     nk_layout_row_dynamic(ctx, 25, 1);
-                    #     nk_button_label(ctx, "#FFAA");
-                    #     nk_button_label(ctx, "#FFBB");
-                    #     nk_button_label(ctx, "#FFCC");
-                    #     nk_button_label(ctx, "#FFDD");
-                    #     nk_button_label(ctx, "#FFEE");
-                    #     nk_button_label(ctx, "#FFFF");
+                    #     nk_button_label(ctx, "#FFAA".encode('utf-8'));
+                    #     nk_button_label(ctx, "#FFBB".encode('utf-8'));
+                    #     nk_button_label(ctx, "#FFCC".encode('utf-8'));
+                    #     nk_button_label(ctx, "#FFDD".encode('utf-8'));
+                    #     nk_button_label(ctx, "#FFEE".encode('utf-8'));
+                    #     nk_button_label(ctx, "#FFFF".encode('utf-8'));
                     #     nk_group_end(ctx);
                     # }
                     pynk.lib.nk_layout_space_push(ctx, pynk.lib.nk_rect(160,0,150,240));
-                    if pynk.lib.nk_group_begin(ctx, "Group_top", pynk.lib.NK_WINDOW_BORDER):
+                    if pynk.lib.nk_group_begin(ctx, "Group_top".encode('utf-8'), pynk.lib.NK_WINDOW_BORDER):
                         pynk.lib.nk_layout_row_dynamic(ctx, 25, 1);
-                        pynk.lib.nk_button_label(ctx, "#FFAA");
-                        pynk.lib.nk_button_label(ctx, "#FFBB");
-                        pynk.lib.nk_button_label(ctx, "#FFCC");
-                        pynk.lib.nk_button_label(ctx, "#FFDD");
-                        pynk.lib.nk_button_label(ctx, "#FFEE");
-                        pynk.lib.nk_button_label(ctx, "#FFFF");
+                        pynk.lib.nk_button_label(ctx, "#FFAA".encode('utf-8'));
+                        pynk.lib.nk_button_label(ctx, "#FFBB".encode('utf-8'));
+                        pynk.lib.nk_button_label(ctx, "#FFCC".encode('utf-8'));
+                        pynk.lib.nk_button_label(ctx, "#FFDD".encode('utf-8'));
+                        pynk.lib.nk_button_label(ctx, "#FFEE".encode('utf-8'));
+                        pynk.lib.nk_button_label(ctx, "#FFFF".encode('utf-8'));
                         pynk.lib.nk_group_end(ctx);
                     #
                     # nk_layout_space_push(ctx, nk_rect(160,250,150,250));
-                    # if (nk_group_begin(ctx, "Group_buttom", NK_WINDOW_BORDER)) {
+                    # if (nk_group_begin(ctx, "Group_buttom".encode('utf-8'), NK_WINDOW_BORDER)) {
                     #     nk_layout_row_dynamic(ctx, 25, 1);
-                    #     nk_button_label(ctx, "#FFAA");
-                    #     nk_button_label(ctx, "#FFBB");
-                    #     nk_button_label(ctx, "#FFCC");
-                    #     nk_button_label(ctx, "#FFDD");
-                    #     nk_button_label(ctx, "#FFEE");
-                    #     nk_button_label(ctx, "#FFFF");
+                    #     nk_button_label(ctx, "#FFAA".encode('utf-8'));
+                    #     nk_button_label(ctx, "#FFBB".encode('utf-8'));
+                    #     nk_button_label(ctx, "#FFCC".encode('utf-8'));
+                    #     nk_button_label(ctx, "#FFDD".encode('utf-8'));
+                    #     nk_button_label(ctx, "#FFEE".encode('utf-8'));
+                    #     nk_button_label(ctx, "#FFFF".encode('utf-8'));
                     #     nk_group_end(ctx);
                     # }
                     pynk.lib.nk_layout_space_push(ctx, pynk.lib.nk_rect(160,250,150,250));
-                    if pynk.lib.nk_group_begin(ctx, "Group_buttom", pynk.lib.NK_WINDOW_BORDER):
+                    if pynk.lib.nk_group_begin(ctx, "Group_buttom".encode('utf-8'), pynk.lib.NK_WINDOW_BORDER):
                         pynk.lib.nk_layout_row_dynamic(ctx, 25, 1);
-                        pynk.lib.nk_button_label(ctx, "#FFAA");
-                        pynk.lib.nk_button_label(ctx, "#FFBB");
-                        pynk.lib.nk_button_label(ctx, "#FFCC");
-                        pynk.lib.nk_button_label(ctx, "#FFDD");
-                        pynk.lib.nk_button_label(ctx, "#FFEE");
-                        pynk.lib.nk_button_label(ctx, "#FFFF");
+                        pynk.lib.nk_button_label(ctx, "#FFAA".encode('utf-8'));
+                        pynk.lib.nk_button_label(ctx, "#FFBB".encode('utf-8'));
+                        pynk.lib.nk_button_label(ctx, "#FFCC".encode('utf-8'));
+                        pynk.lib.nk_button_label(ctx, "#FFDD".encode('utf-8'));
+                        pynk.lib.nk_button_label(ctx, "#FFEE".encode('utf-8'));
+                        pynk.lib.nk_button_label(ctx, "#FFFF".encode('utf-8'));
                         pynk.lib.nk_group_end(ctx);
                     #
                     # nk_layout_space_push(ctx, nk_rect(320,0,150,150));
-                    # if (nk_group_begin(ctx, "Group_right_top", NK_WINDOW_BORDER)) {
+                    # if (nk_group_begin(ctx, "Group_right_top".encode('utf-8'), NK_WINDOW_BORDER)) {
                     #     static int selected[4];
                     #     nk_layout_row_static(ctx, 18, 100, 1);
                     #     for (i = 0; i < 4; ++i)
-                    #         nk_selectable_label(ctx, (selected[i]) ? "Selected": "Unselected", NK_TEXT_CENTERED, &selected[i]);
+                    #         nk_selectable_label(ctx, (selected[i]) ? "Selected".encode('utf-8'): "Unselected".encode('utf-8'), NK_TEXT_CENTERED, &selected[i]);
                     #     nk_group_end(ctx);
                     # }
                     pynk.lib.nk_layout_space_push(ctx, pynk.lib.nk_rect(320,0,150,150));
-                    if pynk.lib.nk_group_begin(ctx, "Group_right_top", pynk.lib.NK_WINDOW_BORDER):
-                        self.declare("selected", [0]*4, "int[]")
+                    if pynk.lib.nk_group_begin(ctx, "Group_right_top".encode('utf-8'), pynk.lib.NK_WINDOW_BORDER):
+                        self.declare("selected".encode('utf-8'), [0]*4, "int[]".encode('utf-8'))
                         pynk.lib.nk_layout_row_static(ctx, 18, 100, 1);
-                        for i in xrange(4):
-                            pynk.lib.nk_selectable_label(ctx, "Selected" if self.selected[i] else "Unselected", pynk.lib.NK_TEXT_CENTERED, self.selected+i);
+                        for i in range(4):
+                            pynk.lib.nk_selectable_label(ctx, "Selected".encode('utf-8') if self.selected[i] else "Unselected".encode('utf-8'), pynk.lib.NK_TEXT_CENTERED, self.selected+i);
                         pynk.lib.nk_group_end(ctx);
                     #
                     # nk_layout_space_push(ctx, nk_rect(320,160,150,150));
-                    # if (nk_group_begin(ctx, "Group_right_center", NK_WINDOW_BORDER)) {
+                    # if (nk_group_begin(ctx, "Group_right_center".encode('utf-8'), NK_WINDOW_BORDER)) {
                     #     static int selected[4];
                     #     nk_layout_row_static(ctx, 18, 100, 1);
                     #     for (i = 0; i < 4; ++i)
-                    #         nk_selectable_label(ctx, (selected[i]) ? "Selected": "Unselected", NK_TEXT_CENTERED, &selected[i]);
+                    #         nk_selectable_label(ctx, (selected[i]) ? "Selected".encode('utf-8'): "Unselected".encode('utf-8'), NK_TEXT_CENTERED, &selected[i]);
                     #     nk_group_end(ctx);
                     # }
                     pynk.lib.nk_layout_space_push(ctx, pynk.lib.nk_rect(320,160,150,150));
-                    if pynk.lib.nk_group_begin(ctx, "Group_right_center", pynk.lib.NK_WINDOW_BORDER):
-                        self.declare("selected", [0]*4, "int[]")
+                    if pynk.lib.nk_group_begin(ctx, "Group_right_center".encode('utf-8'), pynk.lib.NK_WINDOW_BORDER):
+                        self.declare("selected".encode('utf-8'), [0]*4, "int[]".encode('utf-8'))
                         pynk.lib.nk_layout_row_static(ctx, 18, 100, 1);
-                        for i in xrange(4):
-                            pynk.lib.nk_selectable_label(ctx, "Selected" if self.selected[i] else "Unselected", pynk.lib.NK_TEXT_CENTERED, self.selected+i);
+                        for i in range(4):
+                            pynk.lib.nk_selectable_label(ctx, "Selected".encode('utf-8') if self.selected[i] else "Unselected".encode('utf-8'), pynk.lib.NK_TEXT_CENTERED, self.selected+i);
                         pynk.lib.nk_group_end(ctx);
                     #
                     # nk_layout_space_push(ctx, nk_rect(320,320,150,150));
-                    # if (nk_group_begin(ctx, "Group_right_bottom", NK_WINDOW_BORDER)) {
+                    # if (nk_group_begin(ctx, "Group_right_bottom".encode('utf-8'), NK_WINDOW_BORDER)) {
                     #     static int selected[4];
                     #     nk_layout_row_static(ctx, 18, 100, 1);
                     #     for (i = 0; i < 4; ++i)
-                    #         nk_selectable_label(ctx, (selected[i]) ? "Selected": "Unselected", NK_TEXT_CENTERED, &selected[i]);
+                    #         nk_selectable_label(ctx, (selected[i]) ? "Selected".encode('utf-8'): "Unselected".encode('utf-8'), NK_TEXT_CENTERED, &selected[i]);
                     #     nk_group_end(ctx);
                     # }
                     # nk_layout_space_end(ctx);
                     # nk_tree_pop(ctx);
                     pynk.lib.nk_layout_space_push(ctx, pynk.lib.nk_rect(320,320,150,150));
-                    if pynk.lib.nk_group_begin(ctx, "Group_right_bottom", pynk.lib.NK_WINDOW_BORDER):
-                        self.declare("selected", [0]*4, "int[]")
+                    if pynk.lib.nk_group_begin(ctx, "Group_right_bottom".encode('utf-8'), pynk.lib.NK_WINDOW_BORDER):
+                        self.declare("selected".encode('utf-8'), [0]*4, "int[]".encode('utf-8'))
                         pynk.lib.nk_layout_row_static(ctx, 18, 100, 1);
-                        for i in xrange(4):
-                            pynk.lib.nk_selectable_label(ctx, "Selected" if self.selected[i] else "Unselected", pynk.lib.NK_TEXT_CENTERED, self.selected+i);
+                        for i in range(4):
+                            pynk.lib.nk_selectable_label(ctx, "Selected".encode('utf-8') if self.selected[i] else "Unselected".encode('utf-8'), pynk.lib.NK_TEXT_CENTERED, self.selected+i);
                         pynk.lib.nk_group_end(ctx);
                     pynk.lib.nk_layout_space_end(ctx);
                     pynk.lib.nk_tree_pop(ctx);
                 # }
                 #
-                # if (nk_tree_push(ctx, NK_TREE_NODE, "Splitter", NK_MINIMIZED))
+                # if (nk_tree_push(ctx, NK_TREE_NODE, "Splitter".encode('utf-8'), NK_MINIMIZED))
                 # {
-                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Splitter", pynk.lib.NK_MINIMIZED, "20"):
+                if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Splitter".encode('utf-8'), pynk.lib.NK_MINIMIZED, "20".encode('utf-8')):
                     # const struct nk_input *in = &ctx->input;
                     # nk_layout_row_static(ctx, 20, 320, 1);
-                    # nk_label(ctx, "Use slider and spinner to change tile size", NK_TEXT_LEFT);
-                    # nk_label(ctx, "Drag the space between tiles to change tile ratio", NK_TEXT_LEFT);
+                    # nk_label(ctx, "Use slider and spinner to change tile size".encode('utf-8'), NK_TEXT_LEFT);
+                    # nk_label(ctx, "Drag the space between tiles to change tile ratio".encode('utf-8'), NK_TEXT_LEFT);
                     pynk.lib.nk_layout_row_static(ctx, 20, 320, 1);
-                    pynk.lib.nk_label(ctx, "Use slider and spinner to change tile size", pynk.lib.NK_TEXT_LEFT);
-                    pynk.lib.nk_label(ctx, "Drag the space between tiles to change tile ratio", pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_label(ctx, "Use slider and spinner to change tile size".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
+                    pynk.lib.nk_label(ctx, "Drag the space between tiles to change tile ratio".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                     #
-                    # if (nk_tree_push(ctx, NK_TREE_NODE, "Vertical", NK_MINIMIZED))
+                    # if (nk_tree_push(ctx, NK_TREE_NODE, "Vertical".encode('utf-8'), NK_MINIMIZED))
                     # {
-                    if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Vertical", pynk.lib.NK_MINIMIZED, "21"):
+                    if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Vertical".encode('utf-8'), pynk.lib.NK_MINIMIZED, "21".encode('utf-8')):
                         # static float a = 100, b = 100, c = 100;
-                        self.declare("a", 100, "float*")
-                        self.declare("b", 100, "float*")
-                        self.declare("c", 100, "float*")
+                        self.declare("a".encode('utf-8'), 100, "float*".encode('utf-8'))
+                        self.declare("b".encode('utf-8'), 100, "float*".encode('utf-8'))
+                        self.declare("c".encode('utf-8'), 100, "float*".encode('utf-8'))
 
                         # struct nk_rect bounds;
                         #
@@ -2066,21 +2066,21 @@ class Overview(object):
                         #
                         # /* header */
                         # nk_layout_row_static(ctx, 30, 100, 2);
-                        # nk_label(ctx, "left:", NK_TEXT_LEFT);
+                        # nk_label(ctx, "left:".encode('utf-8'), NK_TEXT_LEFT);
                         # nk_slider_float(ctx, 10.0f, &a, 200.0f, 10.0f);
                         #
-                        # nk_label(ctx, "middle:", NK_TEXT_LEFT);
+                        # nk_label(ctx, "middle:".encode('utf-8'), NK_TEXT_LEFT);
                         # nk_slider_float(ctx, 10.0f, &b, 200.0f, 10.0f);
                         #
-                        # nk_label(ctx, "right:", NK_TEXT_LEFT);
+                        # nk_label(ctx, "right:".encode('utf-8'), NK_TEXT_LEFT);
                         # nk_slider_float(ctx, 10.0f, &c, 200.0f, 10.0f);
 
                         pynk.lib.nk_layout_row_static(ctx, 30, 100, 2);
-                        pynk.lib.nk_label(ctx, "left:", pynk.lib.NK_TEXT_LEFT);
+                        pynk.lib.nk_label(ctx, "left:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                         pynk.lib.nk_slider_float(ctx, 10.0, self.a, 200.0, 10.0);
-                        pynk.lib.nk_label(ctx, "middle:", pynk.lib.NK_TEXT_LEFT);
+                        pynk.lib.nk_label(ctx, "middle:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                         pynk.lib.nk_slider_float(ctx, 10.0, self.b, 200.0, 10.0);
-                        pynk.lib.nk_label(ctx, "right:", pynk.lib.NK_TEXT_LEFT);
+                        pynk.lib.nk_label(ctx, "right:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                         pynk.lib.nk_slider_float(ctx, 10.0, self.c, 200.0, 10.0);
 
 
@@ -2090,24 +2090,24 @@ class Overview(object):
                         pynk.lib.nk_layout_row(ctx, pynk.lib.NK_STATIC, 200, 5, row_layout);
                         #
                         # /* left space */
-                        # if (nk_group_begin(ctx, "left", NK_WINDOW_NO_SCROLLBAR|NK_WINDOW_BORDER|NK_WINDOW_NO_SCROLLBAR)) {
+                        # if (nk_group_begin(ctx, "left".encode('utf-8'), NK_WINDOW_NO_SCROLLBAR|NK_WINDOW_BORDER|NK_WINDOW_NO_SCROLLBAR)) {
                         #     nk_layout_row_dynamic(ctx, 25, 1);
-                        #     nk_button_label(ctx, "#FFAA");
-                        #     nk_button_label(ctx, "#FFBB");
-                        #     nk_button_label(ctx, "#FFCC");
-                        #     nk_button_label(ctx, "#FFDD");
-                        #     nk_button_label(ctx, "#FFEE");
-                        #     nk_button_label(ctx, "#FFFF");
+                        #     nk_button_label(ctx, "#FFAA".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFBB".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFCC".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFDD".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFEE".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFFF".encode('utf-8'));
                         #     nk_group_end(ctx);
                         # }
-                        if pynk.lib.nk_group_begin(ctx, "left", pynk.lib.NK_WINDOW_NO_SCROLLBAR|pynk.lib.NK_WINDOW_BORDER|pynk.lib.NK_WINDOW_NO_SCROLLBAR):
+                        if pynk.lib.nk_group_begin(ctx, "left".encode('utf-8'), pynk.lib.NK_WINDOW_NO_SCROLLBAR|pynk.lib.NK_WINDOW_BORDER|pynk.lib.NK_WINDOW_NO_SCROLLBAR):
                             pynk.lib.nk_layout_row_dynamic(ctx, 25, 1);
-                            pynk.lib.nk_button_label(ctx, "#FFAA");
-                            pynk.lib.nk_button_label(ctx, "#FFBB");
-                            pynk.lib.nk_button_label(ctx, "#FFCC");
-                            pynk.lib.nk_button_label(ctx, "#FFDD");
-                            pynk.lib.nk_button_label(ctx, "#FFEE");
-                            pynk.lib.nk_button_label(ctx, "#FFFF");
+                            pynk.lib.nk_button_label(ctx, "#FFAA".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFBB".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFCC".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFDD".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFEE".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFFF".encode('utf-8'));
                             pynk.lib.nk_group_end(ctx);
                         #
                         # /* scaler */
@@ -2120,7 +2120,7 @@ class Overview(object):
                         #     a = row_layout[0] + in->mouse.delta.x;
                         #     b = row_layout[2] - in->mouse.delta.x;
                         # }
-                        ipt = self.get_field_cdata(ctx, "input")
+                        ipt = self.get_field_cdata(ctx, "input".encode('utf-8'))
                         bounds = pynk.lib.nk_widget_bounds(ctx);
                         pynk.lib.nk_spacing(ctx, 1);
                         if (pynk.lib.nk_input_is_mouse_hovering_rect(ipt, bounds) or
@@ -2130,24 +2130,24 @@ class Overview(object):
                             self.b[0] = row_layout[2] - ipt.mouse.delta.x;
                         #
                         # /* middle space */
-                        # if (nk_group_begin(ctx, "center", NK_WINDOW_BORDER|NK_WINDOW_NO_SCROLLBAR)) {
+                        # if (nk_group_begin(ctx, "center".encode('utf-8'), NK_WINDOW_BORDER|NK_WINDOW_NO_SCROLLBAR)) {
                         #     nk_layout_row_dynamic(ctx, 25, 1);
-                        #     nk_button_label(ctx, "#FFAA");
-                        #     nk_button_label(ctx, "#FFBB");
-                        #     nk_button_label(ctx, "#FFCC");
-                        #     nk_button_label(ctx, "#FFDD");
-                        #     nk_button_label(ctx, "#FFEE");
-                        #     nk_button_label(ctx, "#FFFF");
+                        #     nk_button_label(ctx, "#FFAA".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFBB".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFCC".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFDD".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFEE".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFFF".encode('utf-8'));
                         #     nk_group_end(ctx);
                         # }
-                        if pynk.lib.nk_group_begin(ctx, "center", pynk.lib.NK_WINDOW_BORDER|pynk.lib.NK_WINDOW_NO_SCROLLBAR):
+                        if pynk.lib.nk_group_begin(ctx, "center".encode('utf-8'), pynk.lib.NK_WINDOW_BORDER|pynk.lib.NK_WINDOW_NO_SCROLLBAR):
                             pynk.lib.nk_layout_row_dynamic(ctx, 25, 1);
-                            pynk.lib.nk_button_label(ctx, "#FFAA");
-                            pynk.lib.nk_button_label(ctx, "#FFBB");
-                            pynk.lib.nk_button_label(ctx, "#FFCC");
-                            pynk.lib.nk_button_label(ctx, "#FFDD");
-                            pynk.lib.nk_button_label(ctx, "#FFEE");
-                            pynk.lib.nk_button_label(ctx, "#FFFF");
+                            pynk.lib.nk_button_label(ctx, "#FFAA".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFBB".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFCC".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFDD".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFEE".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFFF".encode('utf-8'));
                             pynk.lib.nk_group_end(ctx);
                         #
                         # /* scaler */
@@ -2169,79 +2169,79 @@ class Overview(object):
                             self.c[0] = (row_layout[4] - ipt.mouse.delta.x);
                         #
                         # /* right space */
-                        # if (nk_group_begin(ctx, "right", NK_WINDOW_BORDER|NK_WINDOW_NO_SCROLLBAR)) {
+                        # if (nk_group_begin(ctx, "right".encode('utf-8'), NK_WINDOW_BORDER|NK_WINDOW_NO_SCROLLBAR)) {
                         #     nk_layout_row_dynamic(ctx, 25, 1);
-                        #     nk_button_label(ctx, "#FFAA");
-                        #     nk_button_label(ctx, "#FFBB");
-                        #     nk_button_label(ctx, "#FFCC");
-                        #     nk_button_label(ctx, "#FFDD");
-                        #     nk_button_label(ctx, "#FFEE");
-                        #     nk_button_label(ctx, "#FFFF");
+                        #     nk_button_label(ctx, "#FFAA".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFBB".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFCC".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFDD".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFEE".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFFF".encode('utf-8'));
                         #     nk_group_end(ctx);
                         # }
                         #
                         # nk_tree_pop(ctx);
-                        if pynk.lib.nk_group_begin(ctx, "right", pynk.lib.NK_WINDOW_BORDER|pynk.lib.NK_WINDOW_NO_SCROLLBAR):
+                        if pynk.lib.nk_group_begin(ctx, "right".encode('utf-8'), pynk.lib.NK_WINDOW_BORDER|pynk.lib.NK_WINDOW_NO_SCROLLBAR):
                             pynk.lib.nk_layout_row_dynamic(ctx, 25, 1);
-                            pynk.lib.nk_button_label(ctx, "#FFAA");
-                            pynk.lib.nk_button_label(ctx, "#FFBB");
-                            pynk.lib.nk_button_label(ctx, "#FFCC");
-                            pynk.lib.nk_button_label(ctx, "#FFDD");
-                            pynk.lib.nk_button_label(ctx, "#FFEE");
-                            pynk.lib.nk_button_label(ctx, "#FFFF");
+                            pynk.lib.nk_button_label(ctx, "#FFAA".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFBB".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFCC".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFDD".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFEE".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFFF".encode('utf-8'));
                             pynk.lib.nk_group_end(ctx);
                         pynk.lib.nk_tree_pop(ctx);
                     # }
                     #
-                    # if (nk_tree_push(ctx, NK_TREE_NODE, "Horizontal", NK_MINIMIZED))
+                    # if (nk_tree_push(ctx, NK_TREE_NODE, "Horizontal".encode('utf-8'), NK_MINIMIZED))
                     # {
-                    if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Horizontal", pynk.lib.NK_MINIMIZED, "24"):
+                    if self.tree_push(ctx, pynk.lib.NK_TREE_NODE, "Horizontal".encode('utf-8'), pynk.lib.NK_MINIMIZED, "24".encode('utf-8')):
                         # static float a = 100, b = 100, c = 100;
-                        self.declare("a", 100, "float*")
-                        self.declare("b", 100, "float*")
-                        self.declare("c", 100, "float*")
+                        self.declare("a".encode('utf-8'), 100, "float*".encode('utf-8'))
+                        self.declare("b".encode('utf-8'), 100, "float*".encode('utf-8'))
+                        self.declare("c".encode('utf-8'), 100, "float*".encode('utf-8'))
                         # struct nk_rect bounds;
                         bounds = pynk.ffi.new("struct nk_rect*")
                         #
                         # /* header */
                         # nk_layout_row_static(ctx, 30, 100, 2);
-                        # nk_label(ctx, "top:", NK_TEXT_LEFT);
+                        # nk_label(ctx, "top:".encode('utf-8'), NK_TEXT_LEFT);
                         # nk_slider_float(ctx, 10.0f, &a, 200.0f, 10.0f);
                         #
-                        # nk_label(ctx, "middle:", NK_TEXT_LEFT);
+                        # nk_label(ctx, "middle:".encode('utf-8'), NK_TEXT_LEFT);
                         # nk_slider_float(ctx, 10.0f, &b, 200.0f, 10.0f);
                         #
-                        # nk_label(ctx, "bottom:", NK_TEXT_LEFT);
+                        # nk_label(ctx, "bottom:".encode('utf-8'), NK_TEXT_LEFT);
                         # nk_slider_float(ctx, 10.0f, &c, 200.0f, 10.0f);
                         pynk.lib.nk_layout_row_static(ctx, 30, 100, 2);
-                        pynk.lib.nk_label(ctx, "top:", pynk.lib.NK_TEXT_LEFT);
+                        pynk.lib.nk_label(ctx, "top:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                         pynk.lib.nk_slider_float(ctx, 10.0, self.a, 200.0, 10.0);
-                        pynk.lib.nk_label(ctx, "middle:", pynk.lib.NK_TEXT_LEFT);
+                        pynk.lib.nk_label(ctx, "middle:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                         pynk.lib.nk_slider_float(ctx, 10.0, self.b, 200.0, 10.0);
-                        pynk.lib.nk_label(ctx, "bottom:", pynk.lib.NK_TEXT_LEFT);
+                        pynk.lib.nk_label(ctx, "bottom:".encode('utf-8'), pynk.lib.NK_TEXT_LEFT);
                         pynk.lib.nk_slider_float(ctx, 10.0, self.c, 200.0, 10.0);
                         #
                         # /* top space */
                         # nk_layout_row_dynamic(ctx, a, 1);
-                        # if (nk_group_begin(ctx, "top", NK_WINDOW_NO_SCROLLBAR|NK_WINDOW_BORDER)) {
+                        # if (nk_group_begin(ctx, "top".encode('utf-8'), NK_WINDOW_NO_SCROLLBAR|NK_WINDOW_BORDER)) {
                         #     nk_layout_row_dynamic(ctx, 25, 3);
-                        #     nk_button_label(ctx, "#FFAA");
-                        #     nk_button_label(ctx, "#FFBB");
-                        #     nk_button_label(ctx, "#FFCC");
-                        #     nk_button_label(ctx, "#FFDD");
-                        #     nk_button_label(ctx, "#FFEE");
-                        #     nk_button_label(ctx, "#FFFF");
+                        #     nk_button_label(ctx, "#FFAA".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFBB".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFCC".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFDD".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFEE".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFFF".encode('utf-8'));
                         #     nk_group_end(ctx);
                         # }
                         pynk.lib.nk_layout_row_dynamic(ctx, self.a[0], 1);
-                        if pynk.lib.nk_group_begin(ctx, "top", pynk.lib.NK_WINDOW_NO_SCROLLBAR|pynk.lib.NK_WINDOW_BORDER):
+                        if pynk.lib.nk_group_begin(ctx, "top".encode('utf-8'), pynk.lib.NK_WINDOW_NO_SCROLLBAR|pynk.lib.NK_WINDOW_BORDER):
                             pynk.lib.nk_layout_row_dynamic(ctx, 25, 3);
-                            pynk.lib.nk_button_label(ctx, "#FFAA");
-                            pynk.lib.nk_button_label(ctx, "#FFBB");
-                            pynk.lib.nk_button_label(ctx, "#FFCC");
-                            pynk.lib.nk_button_label(ctx, "#FFDD");
-                            pynk.lib.nk_button_label(ctx, "#FFEE");
-                            pynk.lib.nk_button_label(ctx, "#FFFF");
+                            pynk.lib.nk_button_label(ctx, "#FFAA".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFBB".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFCC".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFDD".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFEE".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFFF".encode('utf-8'));
                             pynk.lib.nk_group_end(ctx);
 
                         #
@@ -2259,7 +2259,7 @@ class Overview(object):
                         pynk.lib.nk_layout_row_dynamic(ctx, 8, 1)
                         bounds = pynk.lib.nk_widget_bounds(ctx);
                         pynk.lib.nk_spacing(ctx, 1);
-                        ipt = self.get_field_cdata(ctx, "input")
+                        ipt = self.get_field_cdata(ctx, "input".encode('utf-8'))
                         if (pynk.lib.nk_input_is_mouse_hovering_rect(
                                 ipt, bounds) or
                                 pynk.lib.nk_input_is_mouse_prev_hovering_rect(
@@ -2272,25 +2272,25 @@ class Overview(object):
                         #
                         # /* middle space */
                         # nk_layout_row_dynamic(ctx, b, 1);
-                        # if (nk_group_begin(ctx, "middle", NK_WINDOW_NO_SCROLLBAR|NK_WINDOW_BORDER)) {
+                        # if (nk_group_begin(ctx, "middle".encode('utf-8'), NK_WINDOW_NO_SCROLLBAR|NK_WINDOW_BORDER)) {
                         #     nk_layout_row_dynamic(ctx, 25, 3);
-                        #     nk_button_label(ctx, "#FFAA");
-                        #     nk_button_label(ctx, "#FFBB");
-                        #     nk_button_label(ctx, "#FFCC");
-                        #     nk_button_label(ctx, "#FFDD");
-                        #     nk_button_label(ctx, "#FFEE");
-                        #     nk_button_label(ctx, "#FFFF");
+                        #     nk_button_label(ctx, "#FFAA".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFBB".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFCC".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFDD".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFEE".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFFF".encode('utf-8'));
                         #     nk_group_end(ctx);
                         # }
                         pynk.lib.nk_layout_row_dynamic(ctx, self.b[0], 1)
-                        if pynk.lib.nk_group_begin(ctx, "middle", pynk.lib.NK_WINDOW_NO_SCROLLBAR|pynk.lib.NK_WINDOW_BORDER):
+                        if pynk.lib.nk_group_begin(ctx, "middle".encode('utf-8'), pynk.lib.NK_WINDOW_NO_SCROLLBAR|pynk.lib.NK_WINDOW_BORDER):
                             pynk.lib.nk_layout_row_dynamic(ctx, 25, 3);
-                            pynk.lib.nk_button_label(ctx, "#FFAA");
-                            pynk.lib.nk_button_label(ctx, "#FFBB");
-                            pynk.lib.nk_button_label(ctx, "#FFCC");
-                            pynk.lib.nk_button_label(ctx, "#FFDD");
-                            pynk.lib.nk_button_label(ctx, "#FFEE");
-                            pynk.lib.nk_button_label(ctx, "#FFFF");
+                            pynk.lib.nk_button_label(ctx, "#FFAA".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFBB".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFCC".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFDD".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFEE".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFFF".encode('utf-8'));
                             pynk.lib.nk_group_end(ctx);
                         #
                         # {
@@ -2315,26 +2315,26 @@ class Overview(object):
                         #
                         # /* bottom space */
                         # nk_layout_row_dynamic(ctx, c, 1);
-                        # if (nk_group_begin(ctx, "bottom", NK_WINDOW_NO_SCROLLBAR|NK_WINDOW_BORDER)) {
+                        # if (nk_group_begin(ctx, "bottom".encode('utf-8'), NK_WINDOW_NO_SCROLLBAR|NK_WINDOW_BORDER)) {
                         #     nk_layout_row_dynamic(ctx, 25, 3);
-                        #     nk_button_label(ctx, "#FFAA");
-                        #     nk_button_label(ctx, "#FFBB");
-                        #     nk_button_label(ctx, "#FFCC");
-                        #     nk_button_label(ctx, "#FFDD");
-                        #     nk_button_label(ctx, "#FFEE");
-                        #     nk_button_label(ctx, "#FFFF");
+                        #     nk_button_label(ctx, "#FFAA".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFBB".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFCC".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFDD".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFEE".encode('utf-8'));
+                        #     nk_button_label(ctx, "#FFFF".encode('utf-8'));
                         #     nk_group_end(ctx);
                         # }
                         # nk_tree_pop(ctx);
                         pynk.lib.nk_layout_row_dynamic(ctx, self.c[0], 1)
-                        if pynk.lib.nk_group_begin(ctx, "bottom", pynk.lib.NK_WINDOW_NO_SCROLLBAR|pynk.lib.NK_WINDOW_BORDER):
+                        if pynk.lib.nk_group_begin(ctx, "bottom".encode('utf-8'), pynk.lib.NK_WINDOW_NO_SCROLLBAR|pynk.lib.NK_WINDOW_BORDER):
                             pynk.lib.nk_layout_row_dynamic(ctx, 25, 3);
-                            pynk.lib.nk_button_label(ctx, "#FFAA");
-                            pynk.lib.nk_button_label(ctx, "#FFBB");
-                            pynk.lib.nk_button_label(ctx, "#FFCC");
-                            pynk.lib.nk_button_label(ctx, "#FFDD");
-                            pynk.lib.nk_button_label(ctx, "#FFEE");
-                            pynk.lib.nk_button_label(ctx, "#FFFF");
+                            pynk.lib.nk_button_label(ctx, "#FFAA".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFBB".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFCC".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFDD".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFEE".encode('utf-8'));
+                            pynk.lib.nk_button_label(ctx, "#FFFF".encode('utf-8'));
                             pynk.lib.nk_group_end(ctx);
                         pynk.lib.nk_tree_pop(ctx)
                     # }
@@ -2346,7 +2346,7 @@ class Overview(object):
             # }
         # }
         # nk_end(ctx);
-        # return !nk_window_is_closed(ctx, "Overview");
+        # return !nk_window_is_closed(ctx, "Overview".encode('utf-8'));
         pynk.lib.nk_end(ctx)
-        return not pynk.lib.nk_window_is_closed(ctx, "PyOverview")
+        return not pynk.lib.nk_window_is_closed(ctx, "PyOverview".encode('utf-8'))
     # }

--- a/nuklear_preprocessed.h
+++ b/nuklear_preprocessed.h
@@ -1,5 +1,11 @@
-#line 402
-typedef char nk_char;
+# 1 "nuklear/nuklear.h"
+# 1 "<built-in>"
+# 1 "<command-line>"
+# 1 "/usr/include/stdc-predef.h" 1 3 4
+# 1 "<command-line>" 2
+# 1 "nuklear/nuklear.h"
+# 398 "nuklear/nuklear.h"
+typedef signed char nk_char;
 typedef unsigned char nk_uchar;
 typedef unsigned char nk_byte;
 typedef signed short nk_short;
@@ -16,15 +22,6 @@ typedef nk_uint nk_rune;
 
 
 
-;
-;
-;
-;
-;
-;
-;
-;
-;
 
 
 
@@ -70,18 +67,18 @@ struct nk_image {nk_handle handle;unsigned short w,h;unsigned short region[4];};
 struct nk_cursor {struct nk_image img; struct nk_vec2 size, offset;};
 struct nk_scroll {nk_uint x, y;};
 
-enum nk_heading         {NK_UP, NK_RIGHT, NK_DOWN, NK_LEFT};
+enum nk_heading {NK_UP, NK_RIGHT, NK_DOWN, NK_LEFT};
 enum nk_button_behavior {NK_BUTTON_DEFAULT, NK_BUTTON_REPEATER};
-enum nk_modify          {NK_FIXED = nk_false, NK_MODIFIABLE = nk_true};
-enum nk_orientation     {NK_VERTICAL, NK_HORIZONTAL};
+enum nk_modify {NK_FIXED = nk_false, NK_MODIFIABLE = nk_true};
+enum nk_orientation {NK_VERTICAL, NK_HORIZONTAL};
 enum nk_collapse_states {NK_MINIMIZED = nk_false, NK_MAXIMIZED = nk_true};
-enum nk_show_states     {NK_HIDDEN = nk_false, NK_SHOWN = nk_true};
-enum nk_chart_type      {NK_CHART_LINES, NK_CHART_COLUMN, NK_CHART_MAX};
-enum nk_chart_event     {NK_CHART_HOVERING = 0x01, NK_CHART_CLICKED = 0x02};
-enum nk_color_format    {NK_RGB, NK_RGBA};
-enum nk_popup_type      {NK_POPUP_STATIC, NK_POPUP_DYNAMIC};
-enum nk_layout_format   {NK_DYNAMIC, NK_STATIC};
-enum nk_tree_type       {NK_TREE_NODE, NK_TREE_TAB};
+enum nk_show_states {NK_HIDDEN = nk_false, NK_SHOWN = nk_true};
+enum nk_chart_type {NK_CHART_LINES, NK_CHART_COLUMN, NK_CHART_MAX};
+enum nk_chart_event {NK_CHART_HOVERING = 0x01, NK_CHART_CLICKED = 0x02};
+enum nk_color_format {NK_RGB, NK_RGBA};
+enum nk_popup_type {NK_POPUP_STATIC, NK_POPUP_DYNAMIC};
+enum nk_layout_format {NK_DYNAMIC, NK_STATIC};
+enum nk_tree_type {NK_TREE_NODE, NK_TREE_TAB};
 
 typedef void*(*nk_plugin_alloc)(nk_handle, void *old, nk_size);
 typedef void (*nk_plugin_free)(nk_handle, void *old);
@@ -110,26 +107,19 @@ enum nk_symbol_type {
     NK_SYMBOL_MINUS,
     NK_SYMBOL_MAX
 };
-#line 557
+# 564 "nuklear/nuklear.h"
 extern int nk_init_default(struct nk_context*, const struct nk_user_font*);
-#line 573
+# 589 "nuklear/nuklear.h"
 extern int nk_init_fixed(struct nk_context*, void *memory, nk_size size, const struct nk_user_font*);
-#line 584
+# 607 "nuklear/nuklear.h"
 extern int nk_init(struct nk_context*, struct nk_allocator*, const struct nk_user_font*);
-#line 596
+# 626 "nuklear/nuklear.h"
 extern int nk_init_custom(struct nk_context*, struct nk_buffer *cmds, struct nk_buffer *pool, const struct nk_user_font*);
-
-
-
-
-
+# 640 "nuklear/nuklear.h"
 extern void nk_clear(struct nk_context*);
-
-
-
-
+# 653 "nuklear/nuklear.h"
 extern void nk_free(struct nk_context*);
-#line 668
+# 735 "nuklear/nuklear.h"
 enum nk_keys {
     NK_KEY_NONE,
     NK_KEY_SHIFT,
@@ -172,44 +162,25 @@ enum nk_buttons {
     NK_BUTTON_DOUBLE,
     NK_BUTTON_MAX
 };
-
-
-
-
+# 789 "nuklear/nuklear.h"
 extern void nk_input_begin(struct nk_context*);
-
-
-
-
-
+# 803 "nuklear/nuklear.h"
 extern void nk_input_motion(struct nk_context*, int x, int y);
-
-
-
-
-
+# 817 "nuklear/nuklear.h"
 extern void nk_input_key(struct nk_context*, enum nk_keys, int down);
-#line 734
+# 833 "nuklear/nuklear.h"
 extern void nk_input_button(struct nk_context*, enum nk_buttons, int x, int y, int down);
-
-
-
-
-
-
+# 848 "nuklear/nuklear.h"
 extern void nk_input_scroll(struct nk_context*, struct nk_vec2 val);
-#line 749
+# 866 "nuklear/nuklear.h"
 extern void nk_input_char(struct nk_context*, char);
-#line 757
+# 883 "nuklear/nuklear.h"
 extern void nk_input_glyph(struct nk_context*, const nk_glyph);
-#line 765
+# 899 "nuklear/nuklear.h"
 extern void nk_input_unicode(struct nk_context*, nk_rune);
-
-
-
-
+# 912 "nuklear/nuklear.h"
 extern void nk_input_end(struct nk_context*);
-#line 977
+# 1142 "nuklear/nuklear.h"
 enum nk_anti_aliasing {NK_ANTI_ALIASING_OFF, NK_ANTI_ALIASING_ON};
 enum nk_convert_result {
     NK_CONVERT_SUCCESS = 0,
@@ -234,367 +205,173 @@ struct nk_convert_config {
     nk_size vertex_size;
     nk_size vertex_alignment;
 };
-
-
-
-
-
-
+# 1180 "nuklear/nuklear.h"
 extern const struct nk_command* nk__begin(struct nk_context*);
-
-
-
-
-
-
+# 1195 "nuklear/nuklear.h"
 extern const struct nk_command* nk__next(struct nk_context*, const struct nk_command*);
-#line 1033
+# 1241 "nuklear/nuklear.h"
 extern nk_flags nk_convert(struct nk_context*, struct nk_buffer *cmds, struct nk_buffer *vertices, struct nk_buffer *elements, const struct nk_convert_config*);
-
-
-
-
-
-
+# 1256 "nuklear/nuklear.h"
 extern const struct nk_draw_command* nk__draw_begin(const struct nk_context*, const struct nk_buffer*);
-
-
-
-
-
-
+# 1271 "nuklear/nuklear.h"
 extern const struct nk_draw_command* nk__draw_end(const struct nk_context*, const struct nk_buffer*);
-#line 1055
+# 1287 "nuklear/nuklear.h"
 extern const struct nk_draw_command* nk__draw_next(const struct nk_draw_command*, const struct nk_buffer*, const struct nk_context*);
-#line 1181
+# 1448 "nuklear/nuklear.h"
 enum nk_panel_flags {
-    NK_WINDOW_BORDER            = (1 << (0)),
-    NK_WINDOW_MOVABLE           = (1 << (1)),
-    NK_WINDOW_SCALABLE          = (1 << (2)),
-    NK_WINDOW_CLOSABLE          = (1 << (3)),
-    NK_WINDOW_MINIMIZABLE       = (1 << (4)),
-    NK_WINDOW_NO_SCROLLBAR      = (1 << (5)),
-    NK_WINDOW_TITLE             = (1 << (6)),
-    NK_WINDOW_SCROLL_AUTO_HIDE  = (1 << (7)),
-    NK_WINDOW_BACKGROUND        = (1 << (8)),
-    NK_WINDOW_SCALE_LEFT        = (1 << (9)),
-    NK_WINDOW_NO_INPUT          = (1 << (10))
+    NK_WINDOW_BORDER = (1 << (0)),
+    NK_WINDOW_MOVABLE = (1 << (1)),
+    NK_WINDOW_SCALABLE = (1 << (2)),
+    NK_WINDOW_CLOSABLE = (1 << (3)),
+    NK_WINDOW_MINIMIZABLE = (1 << (4)),
+    NK_WINDOW_NO_SCROLLBAR = (1 << (5)),
+    NK_WINDOW_TITLE = (1 << (6)),
+    NK_WINDOW_SCROLL_AUTO_HIDE = (1 << (7)),
+    NK_WINDOW_BACKGROUND = (1 << (8)),
+    NK_WINDOW_SCALE_LEFT = (1 << (9)),
+    NK_WINDOW_NO_INPUT = (1 << (10))
 };
-#line 1202
+# 1479 "nuklear/nuklear.h"
 extern int nk_begin(struct nk_context *ctx, const char *title, struct nk_rect bounds, nk_flags flags);
-#line 1212
+# 1499 "nuklear/nuklear.h"
 extern int nk_begin_titled(struct nk_context *ctx, const char *name, const char *title, struct nk_rect bounds, nk_flags flags);
-
-
-
-
+# 1512 "nuklear/nuklear.h"
 extern void nk_end(struct nk_context *ctx);
-
-
-
-
-
-
+# 1528 "nuklear/nuklear.h"
 extern struct nk_window *nk_window_find(struct nk_context *ctx, const char *name);
-
-
-
-
-
-
+# 1544 "nuklear/nuklear.h"
 extern struct nk_rect nk_window_get_bounds(const struct nk_context *ctx);
-
-
-
-
-
-
+# 1560 "nuklear/nuklear.h"
 extern struct nk_vec2 nk_window_get_position(const struct nk_context *ctx);
-
-
-
-
-
-
+# 1576 "nuklear/nuklear.h"
 extern struct nk_vec2 nk_window_get_size(const struct nk_context*);
-
-
-
-
-
-
+# 1592 "nuklear/nuklear.h"
 extern float nk_window_get_width(const struct nk_context*);
-
-
-
-
-
-
+# 1608 "nuklear/nuklear.h"
 extern float nk_window_get_height(const struct nk_context*);
-
-
-
-
-
-
+# 1626 "nuklear/nuklear.h"
 extern struct nk_panel* nk_window_get_panel(struct nk_context*);
-
-
-
-
-
-
+# 1645 "nuklear/nuklear.h"
 extern struct nk_rect nk_window_get_content_region(struct nk_context*);
-
-
-
-
-
-
+# 1664 "nuklear/nuklear.h"
 extern struct nk_vec2 nk_window_get_content_region_min(struct nk_context*);
-
-
-
-
-
-
+# 1683 "nuklear/nuklear.h"
 extern struct nk_vec2 nk_window_get_content_region_max(struct nk_context*);
-
-
-
-
-
-
+# 1701 "nuklear/nuklear.h"
 extern struct nk_vec2 nk_window_get_content_region_size(struct nk_context*);
-
-
-
-
-
-
+# 1720 "nuklear/nuklear.h"
 extern struct nk_command_buffer* nk_window_get_canvas(struct nk_context*);
-
-
-
-
-
-
+# 1735 "nuklear/nuklear.h"
 extern int nk_window_has_focus(const struct nk_context*);
-
-
-
-
-
-
-extern int nk_window_is_collapsed(struct nk_context *ctx, const char *name);
-
-
-
-
-
-
-extern int nk_window_is_closed(struct nk_context*, const char*);
-
-
-
-
-
-
-extern int nk_window_is_hidden(struct nk_context*, const char*);
-
-
-
-
-
-
-extern int nk_window_is_active(struct nk_context*, const char*);
-
-
-
-
-
-
+# 1750 "nuklear/nuklear.h"
 extern int nk_window_is_hovered(struct nk_context*);
-
-
-
-
-
+# 1765 "nuklear/nuklear.h"
+extern int nk_window_is_collapsed(struct nk_context *ctx, const char *name);
+# 1779 "nuklear/nuklear.h"
+extern int nk_window_is_closed(struct nk_context*, const char*);
+# 1793 "nuklear/nuklear.h"
+extern int nk_window_is_hidden(struct nk_context*, const char*);
+# 1807 "nuklear/nuklear.h"
+extern int nk_window_is_active(struct nk_context*, const char*);
+# 1820 "nuklear/nuklear.h"
 extern int nk_window_is_any_hovered(struct nk_context*);
-#line 1357
+# 1835 "nuklear/nuklear.h"
 extern int nk_item_is_any_active(struct nk_context*);
-
-
-
-
-
-
+# 1848 "nuklear/nuklear.h"
 extern void nk_window_set_bounds(struct nk_context*, const char *name, struct nk_rect bounds);
-
-
-
-
-
-
+# 1861 "nuklear/nuklear.h"
 extern void nk_window_set_position(struct nk_context*, const char *name, struct nk_vec2 pos);
-
-
-
-
-
-
+# 1874 "nuklear/nuklear.h"
 extern void nk_window_set_size(struct nk_context*, const char *name, struct nk_vec2);
-
-
-
-
+# 1886 "nuklear/nuklear.h"
 extern void nk_window_set_focus(struct nk_context*, const char *name);
-
-
-
-
+# 1898 "nuklear/nuklear.h"
 extern void nk_window_close(struct nk_context *ctx, const char *name);
-
-
-
-
+# 1911 "nuklear/nuklear.h"
 extern void nk_window_collapse(struct nk_context*, const char *name, enum nk_collapse_states state);
-
-
-
-
-
-
+# 1925 "nuklear/nuklear.h"
 extern void nk_window_collapse_if(struct nk_context*, const char *name, enum nk_collapse_states, int cond);
-
-
-
-
-
+# 1938 "nuklear/nuklear.h"
 extern void nk_window_show(struct nk_context*, const char *name, enum nk_show_states);
-
-
-
-
-
-
+# 1952 "nuklear/nuklear.h"
 extern void nk_window_show_if(struct nk_context*, const char *name, enum nk_show_states, int cond);
-#line 1677
+# 2241 "nuklear/nuklear.h"
 extern void nk_layout_set_min_row_height(struct nk_context*, float height);
-
-
-
-
+# 2252 "nuklear/nuklear.h"
 extern void nk_layout_reset_min_row_height(struct nk_context*);
-
-
-
+# 2265 "nuklear/nuklear.h"
 extern struct nk_rect nk_layout_widget_bounds(struct nk_context*);
-
-
-
-
+# 2279 "nuklear/nuklear.h"
 extern float nk_layout_ratio_from_pixel(struct nk_context*, float pixel_width);
-#line 1699
+# 2294 "nuklear/nuklear.h"
 extern void nk_layout_row_dynamic(struct nk_context *ctx, float height, int cols);
-#line 1708
+# 2310 "nuklear/nuklear.h"
 extern void nk_layout_row_static(struct nk_context *ctx, float height, int item_width, int cols);
-
-
-
-
-
-
+# 2324 "nuklear/nuklear.h"
 extern void nk_layout_row_begin(struct nk_context *ctx, enum nk_layout_format fmt, float row_height, int cols);
-
-
-
-
+# 2336 "nuklear/nuklear.h"
 extern void nk_layout_row_push(struct nk_context*, float value);
-
-
-
+# 2347 "nuklear/nuklear.h"
 extern void nk_layout_row_end(struct nk_context*);
-
-
-
-
-
-
+# 2361 "nuklear/nuklear.h"
 extern void nk_layout_row(struct nk_context*, enum nk_layout_format, float height, int cols, const float *ratio);
-
-
-
-
+# 2373 "nuklear/nuklear.h"
 extern void nk_layout_row_template_begin(struct nk_context*, float row_height);
-
-
-
+# 2385 "nuklear/nuklear.h"
 extern void nk_layout_row_template_push_dynamic(struct nk_context*);
-
-
-
-
+# 2397 "nuklear/nuklear.h"
 extern void nk_layout_row_template_push_variable(struct nk_context*, float min_width);
-
-
-
-
+# 2409 "nuklear/nuklear.h"
 extern void nk_layout_row_template_push_static(struct nk_context*, float width);
-
-
-
+# 2420 "nuklear/nuklear.h"
 extern void nk_layout_row_template_end(struct nk_context*);
-
-
-
-
-
-
+# 2434 "nuklear/nuklear.h"
 extern void nk_layout_space_begin(struct nk_context*, enum nk_layout_format, float height, int widget_count);
-
-
-
-
-extern void nk_layout_space_push(struct nk_context*, struct nk_rect);
-
-
-
+# 2446 "nuklear/nuklear.h"
+extern void nk_layout_space_push(struct nk_context*, struct nk_rect bounds);
+# 2457 "nuklear/nuklear.h"
 extern void nk_layout_space_end(struct nk_context*);
-
-
-
+# 2470 "nuklear/nuklear.h"
 extern struct nk_rect nk_layout_space_bounds(struct nk_context*);
-
-
-
-
+# 2484 "nuklear/nuklear.h"
 extern struct nk_vec2 nk_layout_space_to_screen(struct nk_context*, struct nk_vec2);
-
-
-
-
+# 2498 "nuklear/nuklear.h"
 extern struct nk_vec2 nk_layout_space_to_local(struct nk_context*, struct nk_vec2);
-
-
-
-
+# 2512 "nuklear/nuklear.h"
 extern struct nk_rect nk_layout_space_rect_to_screen(struct nk_context*, struct nk_rect);
-
-
-
-
+# 2526 "nuklear/nuklear.h"
 extern struct nk_rect nk_layout_space_rect_to_local(struct nk_context*, struct nk_rect);
-
-
-
-
-
+# 2627 "nuklear/nuklear.h"
 extern int nk_group_begin(struct nk_context*, const char *title, nk_flags);
-extern int nk_group_scrolled_offset_begin(struct nk_context*, nk_uint *x_offset, nk_uint *y_offset, const char*, nk_flags);
-extern int nk_group_scrolled_begin(struct nk_context*, struct nk_scroll*, const char *title, nk_flags);
-extern void nk_group_scrolled_end(struct nk_context*);
+# 2643 "nuklear/nuklear.h"
+extern int nk_group_begin_titled(struct nk_context*, const char *name, const char *title, nk_flags);
+# 2654 "nuklear/nuklear.h"
 extern void nk_group_end(struct nk_context*);
+# 2672 "nuklear/nuklear.h"
+extern int nk_group_scrolled_offset_begin(struct nk_context*, nk_uint *x_offset, nk_uint *y_offset, const char *title, nk_flags flags);
+# 2689 "nuklear/nuklear.h"
+extern int nk_group_scrolled_begin(struct nk_context*, struct nk_scroll *off, const char *title, nk_flags);
+# 2700 "nuklear/nuklear.h"
+extern void nk_group_scrolled_end(struct nk_context*);
+# 2829 "nuklear/nuklear.h"
+extern int nk_tree_push_hashed(struct nk_context*, enum nk_tree_type, const char *title, enum nk_collapse_states initial_state, const char *hash, int len,int seed);
+# 2893 "nuklear/nuklear.h"
+extern int nk_tree_image_push_hashed(struct nk_context*, enum nk_tree_type, struct nk_image, const char *title, enum nk_collapse_states initial_state, const char *hash, int len,int seed);
+# 2904 "nuklear/nuklear.h"
+extern void nk_tree_pop(struct nk_context*);
+# 2920 "nuklear/nuklear.h"
+extern int nk_tree_state_push(struct nk_context*, enum nk_tree_type, const char *title, enum nk_collapse_states *state);
+# 2937 "nuklear/nuklear.h"
+extern int nk_tree_state_image_push(struct nk_context*, enum nk_tree_type, struct nk_image, const char *title, enum nk_collapse_states *state);
+# 2948 "nuklear/nuklear.h"
+extern void nk_tree_state_pop(struct nk_context*);
+
+
+
+extern int nk_tree_element_push_hashed(struct nk_context*, enum nk_tree_type, const char *title, enum nk_collapse_states initial_state, int *selected, const char *hash, int len, int seed);
+extern int nk_tree_element_image_push_hashed(struct nk_context*, enum nk_tree_type, struct nk_image, const char *title, enum nk_collapse_states initial_state, int *selected, const char *hash, int len,int seed);
+extern void nk_tree_element_pop(struct nk_context*);
+
 
 
 
@@ -611,15 +388,6 @@ struct nk_list_view {
 };
 extern int nk_list_view_begin(struct nk_context*, struct nk_list_view *out, const char *id, nk_flags, int row_height, int row_count);
 extern void nk_list_view_end(struct nk_list_view*);
-#line 1828
-extern int nk_tree_push_hashed(struct nk_context*, enum nk_tree_type, const char *title, enum nk_collapse_states initial_state, const char *hash, int len,int seed);
-
-
-extern int nk_tree_image_push_hashed(struct nk_context*, enum nk_tree_type, struct nk_image, const char *title, enum nk_collapse_states initial_state, const char *hash, int len,int seed);
-extern void nk_tree_pop(struct nk_context*);
-extern int nk_tree_state_push(struct nk_context*, enum nk_tree_type, const char *title, enum nk_collapse_states *state);
-extern int nk_tree_state_image_push(struct nk_context*, enum nk_tree_type, struct nk_image, const char *title, enum nk_collapse_states *state);
-extern void nk_tree_state_pop(struct nk_context*);
 
 
 
@@ -631,14 +399,14 @@ enum nk_widget_layout_states {
     NK_WIDGET_ROM
 };
 enum nk_widget_states {
-    NK_WIDGET_STATE_MODIFIED    = (1 << (1)),
-    NK_WIDGET_STATE_INACTIVE    = (1 << (2)),
-    NK_WIDGET_STATE_ENTERED     = (1 << (3)),
-    NK_WIDGET_STATE_HOVER       = (1 << (4)),
-    NK_WIDGET_STATE_ACTIVED     = (1 << (5)),
-    NK_WIDGET_STATE_LEFT        = (1 << (6)),
-    NK_WIDGET_STATE_HOVERED     = NK_WIDGET_STATE_HOVER|NK_WIDGET_STATE_MODIFIED,
-    NK_WIDGET_STATE_ACTIVE      = NK_WIDGET_STATE_ACTIVED|NK_WIDGET_STATE_MODIFIED
+    NK_WIDGET_STATE_MODIFIED = (1 << (1)),
+    NK_WIDGET_STATE_INACTIVE = (1 << (2)),
+    NK_WIDGET_STATE_ENTERED = (1 << (3)),
+    NK_WIDGET_STATE_HOVER = (1 << (4)),
+    NK_WIDGET_STATE_ACTIVED = (1 << (5)),
+    NK_WIDGET_STATE_LEFT = (1 << (6)),
+    NK_WIDGET_STATE_HOVERED = NK_WIDGET_STATE_HOVER|NK_WIDGET_STATE_MODIFIED,
+    NK_WIDGET_STATE_ACTIVE = NK_WIDGET_STATE_ACTIVED|NK_WIDGET_STATE_MODIFIED
 };
 extern enum nk_widget_layout_states nk_widget(struct nk_rect*, const struct nk_context*);
 extern enum nk_widget_layout_states nk_widget_fitting(struct nk_rect*, struct nk_context*, struct nk_vec2);
@@ -657,17 +425,17 @@ extern void nk_spacing(struct nk_context*, int cols);
 
 
 enum nk_text_align {
-    NK_TEXT_ALIGN_LEFT        = 0x01,
-    NK_TEXT_ALIGN_CENTERED    = 0x02,
-    NK_TEXT_ALIGN_RIGHT       = 0x04,
-    NK_TEXT_ALIGN_TOP         = 0x08,
-    NK_TEXT_ALIGN_MIDDLE      = 0x10,
-    NK_TEXT_ALIGN_BOTTOM      = 0x20
+    NK_TEXT_ALIGN_LEFT = 0x01,
+    NK_TEXT_ALIGN_CENTERED = 0x02,
+    NK_TEXT_ALIGN_RIGHT = 0x04,
+    NK_TEXT_ALIGN_TOP = 0x08,
+    NK_TEXT_ALIGN_MIDDLE = 0x10,
+    NK_TEXT_ALIGN_BOTTOM = 0x20
 };
 enum nk_text_alignment {
-    NK_TEXT_LEFT        = NK_TEXT_ALIGN_MIDDLE|NK_TEXT_ALIGN_LEFT,
-    NK_TEXT_CENTERED    = NK_TEXT_ALIGN_MIDDLE|NK_TEXT_ALIGN_CENTERED,
-    NK_TEXT_RIGHT       = NK_TEXT_ALIGN_MIDDLE|NK_TEXT_ALIGN_RIGHT
+    NK_TEXT_LEFT = NK_TEXT_ALIGN_MIDDLE|NK_TEXT_ALIGN_LEFT,
+    NK_TEXT_CENTERED = NK_TEXT_ALIGN_MIDDLE|NK_TEXT_ALIGN_CENTERED,
+    NK_TEXT_RIGHT = NK_TEXT_ALIGN_MIDDLE|NK_TEXT_ALIGN_RIGHT
 };
 extern void nk_text(struct nk_context*, const char*, int, nk_flags);
 extern void nk_text_colored(struct nk_context*, const char*, int, nk_flags, struct nk_color);
@@ -678,24 +446,8 @@ extern void nk_label_colored(struct nk_context*, const char*, nk_flags align, st
 extern void nk_label_wrap(struct nk_context*, const char*);
 extern void nk_label_colored_wrap(struct nk_context*, const char*, struct nk_color);
 extern void nk_image(struct nk_context*, struct nk_image);
-
-extern void nk_labelf(struct nk_context*, nk_flags, const char*, ...);
-extern void nk_labelf_colored(struct nk_context*, nk_flags align, struct nk_color, const char*,...);
-extern void nk_labelf_wrap(struct nk_context*, const char*,...);
-extern void nk_labelf_colored_wrap(struct nk_context*, struct nk_color, const char*,...);
-extern void nk_value_bool(struct nk_context*, const char *prefix, int);
-extern void nk_value_int(struct nk_context*, const char *prefix, int);
-extern void nk_value_uint(struct nk_context*, const char *prefix, unsigned int);
-extern void nk_value_float(struct nk_context*, const char *prefix, float);
-extern void nk_value_color_byte(struct nk_context*, const char *prefix, struct nk_color);
-extern void nk_value_color_float(struct nk_context*, const char *prefix, struct nk_color);
-extern void nk_value_color_hex(struct nk_context*, const char *prefix, struct nk_color);
-
-
-
-
-
-
+extern void nk_image_color(struct nk_context*, struct nk_image, struct nk_color);
+# 3053 "nuklear/nuklear.h"
 extern int nk_button_text(struct nk_context*, const char *title, int len);
 extern int nk_button_label(struct nk_context*, const char *title);
 extern int nk_button_color(struct nk_context*, struct nk_color);
@@ -745,12 +497,18 @@ extern int nk_option_text(struct nk_context*, const char*, int, int active);
 
 extern int nk_selectable_label(struct nk_context*, const char*, nk_flags align, int *value);
 extern int nk_selectable_text(struct nk_context*, const char*, int, nk_flags align, int *value);
-extern int nk_selectable_image_label(struct nk_context*,struct nk_image,  const char*, nk_flags align, int *value);
+extern int nk_selectable_image_label(struct nk_context*,struct nk_image, const char*, nk_flags align, int *value);
 extern int nk_selectable_image_text(struct nk_context*,struct nk_image, const char*, int, nk_flags align, int *value);
+extern int nk_selectable_symbol_label(struct nk_context*,enum nk_symbol_type, const char*, nk_flags align, int *value);
+extern int nk_selectable_symbol_text(struct nk_context*,enum nk_symbol_type, const char*, int, nk_flags align, int *value);
+
 extern int nk_select_label(struct nk_context*, const char*, nk_flags align, int value);
 extern int nk_select_text(struct nk_context*, const char*, int, nk_flags align, int value);
 extern int nk_select_image_label(struct nk_context*, struct nk_image,const char*, nk_flags align, int value);
 extern int nk_select_image_text(struct nk_context*, struct nk_image,const char*, int, nk_flags align, int value);
+extern int nk_select_symbol_label(struct nk_context*,enum nk_symbol_type, const char*, nk_flags align, int value);
+extern int nk_select_symbol_text(struct nk_context*,enum nk_symbol_type, const char*, int, nk_flags align, int value);
+
 
 
 
@@ -773,18 +531,19 @@ extern nk_size nk_prog(struct nk_context*, nk_size cur, nk_size max, int modifya
 
 
 
-extern struct nk_color nk_color_picker(struct nk_context*, struct nk_color, enum nk_color_format);
-extern int nk_color_pick(struct nk_context*, struct nk_color*, enum nk_color_format);
-
-
-
-
-
+extern struct nk_colorf nk_color_picker(struct nk_context*, struct nk_colorf, enum nk_color_format);
+extern int nk_color_pick(struct nk_context*, struct nk_colorf*, enum nk_color_format);
+# 3234 "nuklear/nuklear.h"
 extern void nk_property_int(struct nk_context*, const char *name, int min, int *val, int max, int step, float inc_per_pixel);
+# 3255 "nuklear/nuklear.h"
 extern void nk_property_float(struct nk_context*, const char *name, float min, float *val, float max, float step, float inc_per_pixel);
+# 3276 "nuklear/nuklear.h"
 extern void nk_property_double(struct nk_context*, const char *name, double min, double *val, double max, double step, float inc_per_pixel);
+# 3299 "nuklear/nuklear.h"
 extern int nk_propertyi(struct nk_context*, const char *name, int min, int val, int max, int step, float inc_per_pixel);
+# 3322 "nuklear/nuklear.h"
 extern float nk_propertyf(struct nk_context*, const char *name, float min, float val, float max, float step, float inc_per_pixel);
+# 3345 "nuklear/nuklear.h"
 extern double nk_propertyd(struct nk_context*, const char *name, double min, double val, double max, double step, float inc_per_pixel);
 
 
@@ -792,32 +551,32 @@ extern double nk_propertyd(struct nk_context*, const char *name, double min, dou
 
 
 enum nk_edit_flags {
-    NK_EDIT_DEFAULT                 = 0,
-    NK_EDIT_READ_ONLY               = (1 << (0)),
-    NK_EDIT_AUTO_SELECT             = (1 << (1)),
-    NK_EDIT_SIG_ENTER               = (1 << (2)),
-    NK_EDIT_ALLOW_TAB               = (1 << (3)),
-    NK_EDIT_NO_CURSOR               = (1 << (4)),
-    NK_EDIT_SELECTABLE              = (1 << (5)),
-    NK_EDIT_CLIPBOARD               = (1 << (6)),
-    NK_EDIT_CTRL_ENTER_NEWLINE      = (1 << (7)),
-    NK_EDIT_NO_HORIZONTAL_SCROLL    = (1 << (8)),
-    NK_EDIT_ALWAYS_INSERT_MODE      = (1 << (9)),
-    NK_EDIT_MULTILINE               = (1 << (10)),
-    NK_EDIT_GOTO_END_ON_ACTIVATE    = (1 << (11))
+    NK_EDIT_DEFAULT = 0,
+    NK_EDIT_READ_ONLY = (1 << (0)),
+    NK_EDIT_AUTO_SELECT = (1 << (1)),
+    NK_EDIT_SIG_ENTER = (1 << (2)),
+    NK_EDIT_ALLOW_TAB = (1 << (3)),
+    NK_EDIT_NO_CURSOR = (1 << (4)),
+    NK_EDIT_SELECTABLE = (1 << (5)),
+    NK_EDIT_CLIPBOARD = (1 << (6)),
+    NK_EDIT_CTRL_ENTER_NEWLINE = (1 << (7)),
+    NK_EDIT_NO_HORIZONTAL_SCROLL = (1 << (8)),
+    NK_EDIT_ALWAYS_INSERT_MODE = (1 << (9)),
+    NK_EDIT_MULTILINE = (1 << (10)),
+    NK_EDIT_GOTO_END_ON_ACTIVATE = (1 << (11))
 };
 enum nk_edit_types {
-    NK_EDIT_SIMPLE  = NK_EDIT_ALWAYS_INSERT_MODE,
-    NK_EDIT_FIELD   = NK_EDIT_SIMPLE|NK_EDIT_SELECTABLE|NK_EDIT_CLIPBOARD,
-    NK_EDIT_BOX     = NK_EDIT_ALWAYS_INSERT_MODE| NK_EDIT_SELECTABLE| NK_EDIT_MULTILINE|NK_EDIT_ALLOW_TAB|NK_EDIT_CLIPBOARD,
-    NK_EDIT_EDITOR  = NK_EDIT_SELECTABLE|NK_EDIT_MULTILINE|NK_EDIT_ALLOW_TAB| NK_EDIT_CLIPBOARD
+    NK_EDIT_SIMPLE = NK_EDIT_ALWAYS_INSERT_MODE,
+    NK_EDIT_FIELD = NK_EDIT_SIMPLE|NK_EDIT_SELECTABLE|NK_EDIT_CLIPBOARD,
+    NK_EDIT_BOX = NK_EDIT_ALWAYS_INSERT_MODE| NK_EDIT_SELECTABLE| NK_EDIT_MULTILINE|NK_EDIT_ALLOW_TAB|NK_EDIT_CLIPBOARD,
+    NK_EDIT_EDITOR = NK_EDIT_SELECTABLE|NK_EDIT_MULTILINE|NK_EDIT_ALLOW_TAB| NK_EDIT_CLIPBOARD
 };
 enum nk_edit_events {
-    NK_EDIT_ACTIVE      = (1 << (0)),
-    NK_EDIT_INACTIVE    = (1 << (1)),
-    NK_EDIT_ACTIVATED   = (1 << (2)),
+    NK_EDIT_ACTIVE = (1 << (0)),
+    NK_EDIT_INACTIVE = (1 << (1)),
+    NK_EDIT_ACTIVATED = (1 << (2)),
     NK_EDIT_DEACTIVATED = (1 << (3)),
-    NK_EDIT_COMMITED    = (1 << (4))
+    NK_EDIT_COMMITED = (1 << (4))
 };
 extern nk_flags nk_edit_string(struct nk_context*, nk_flags, char *buffer, int *len, int max, nk_plugin_filter);
 extern nk_flags nk_edit_string_zero_terminated(struct nk_context*, nk_flags, char *buffer, int max, nk_plugin_filter);
@@ -867,12 +626,12 @@ extern void nk_combobox_callback(struct nk_context*, void(*item_getter)(void*, i
 extern int nk_combo_begin_text(struct nk_context*, const char *selected, int, struct nk_vec2 size);
 extern int nk_combo_begin_label(struct nk_context*, const char *selected, struct nk_vec2 size);
 extern int nk_combo_begin_color(struct nk_context*, struct nk_color color, struct nk_vec2 size);
-extern int nk_combo_begin_symbol(struct nk_context*,  enum nk_symbol_type,  struct nk_vec2 size);
+extern int nk_combo_begin_symbol(struct nk_context*, enum nk_symbol_type, struct nk_vec2 size);
 extern int nk_combo_begin_symbol_label(struct nk_context*, const char *selected, enum nk_symbol_type, struct nk_vec2 size);
 extern int nk_combo_begin_symbol_text(struct nk_context*, const char *selected, int, enum nk_symbol_type, struct nk_vec2 size);
-extern int nk_combo_begin_image(struct nk_context*, struct nk_image img,  struct nk_vec2 size);
+extern int nk_combo_begin_image(struct nk_context*, struct nk_image img, struct nk_vec2 size);
 extern int nk_combo_begin_image_label(struct nk_context*, const char *selected, struct nk_image, struct nk_vec2 size);
-extern int nk_combo_begin_image_text(struct nk_context*,  const char *selected, int, struct nk_image, struct nk_vec2 size);
+extern int nk_combo_begin_image_text(struct nk_context*, const char *selected, int, struct nk_image, struct nk_vec2 size);
 extern int nk_combo_item_label(struct nk_context*, const char*, nk_flags alignment);
 extern int nk_combo_item_text(struct nk_context*, const char*,int, nk_flags alignment);
 extern int nk_combo_item_image_label(struct nk_context*, struct nk_image, const char*, nk_flags alignment);
@@ -902,7 +661,8 @@ extern void nk_contextual_end(struct nk_context*);
 
 extern void nk_tooltip(struct nk_context*, const char*);
 
-extern void nk_tooltipf(struct nk_context*, const char*, ...);
+
+
 
 extern int nk_tooltip_begin(struct nk_context*, float width);
 extern void nk_tooltip_end(struct nk_context*);
@@ -1008,6 +768,7 @@ extern struct nk_color nk_rgb_iv(const int *rgb);
 extern struct nk_color nk_rgb_bv(const nk_byte* rgb);
 extern struct nk_color nk_rgb_f(float r, float g, float b);
 extern struct nk_color nk_rgb_fv(const float *rgb);
+extern struct nk_color nk_rgb_cf(struct nk_colorf c);
 extern struct nk_color nk_rgb_hex(const char *rgb);
 
 extern struct nk_color nk_rgba(int r, int g, int b, int a);
@@ -1016,7 +777,13 @@ extern struct nk_color nk_rgba_iv(const int *rgba);
 extern struct nk_color nk_rgba_bv(const nk_byte *rgba);
 extern struct nk_color nk_rgba_f(float r, float g, float b, float a);
 extern struct nk_color nk_rgba_fv(const float *rgba);
+extern struct nk_color nk_rgba_cf(struct nk_colorf c);
 extern struct nk_color nk_rgba_hex(const char *rgb);
+
+extern struct nk_colorf nk_hsva_colorf(float h, float s, float v, float a);
+extern struct nk_colorf nk_hsva_colorfv(float *c);
+extern void nk_colorf_hsva_f(float *out_h, float *out_s, float *out_v, float *out_a, struct nk_colorf in);
+extern void nk_colorf_hsva_fv(float *hsva, struct nk_colorf in);
 
 extern struct nk_color nk_hsv(int h, int s, int v);
 extern struct nk_color nk_hsv_iv(const int *hsv);
@@ -1033,6 +800,7 @@ extern struct nk_color nk_hsva_fv(const float *hsva);
 
 extern void nk_color_f(float *r, float *g, float *b, float *a, struct nk_color);
 extern void nk_color_fv(float *rgba_out, struct nk_color);
+extern struct nk_colorf nk_color_cf(struct nk_color);
 extern void nk_color_d(double *r, double *g, double *b, double *a, struct nk_color);
 extern void nk_color_dv(double *rgba_out, struct nk_color);
 
@@ -1111,7 +879,7 @@ extern int nk_utf_decode(const char*, nk_rune*, int);
 extern int nk_utf_encode(nk_rune, char*, int);
 extern int nk_utf_len(const char*, int byte_len);
 extern const char* nk_utf_at(const char *buffer, int length, int index, nk_rune *unicode, int *len);
-#line 2476
+# 3829 "nuklear/nuklear.h"
 struct nk_user_font_glyph;
 typedef float(*nk_text_width_f)(nk_handle, float h, const char*, int len);
 typedef void(*nk_query_font_glyph_f)(nk_handle handle, float font_height,
@@ -1145,135 +913,7 @@ struct nk_user_font {
 
 
 };
-
-
-enum nk_font_coord_type {
-    NK_COORD_UV,
-    NK_COORD_PIXEL
-};
-
-struct nk_font;
-struct nk_baked_font {
-    float height;
-
-    float ascent, descent;
-
-    nk_rune glyph_offset;
-
-    nk_rune glyph_count;
-
-    const nk_rune *ranges;
-
-};
-
-struct nk_font_config {
-    struct nk_font_config *next;
-
-    void *ttf_blob;
-
-
-    nk_size ttf_size;
-
-
-
-    unsigned char ttf_data_owned_by_atlas;
-
-    unsigned char merge_mode;
-
-    unsigned char pixel_snap;
-
-    unsigned char oversample_v, oversample_h;
-
-    unsigned char padding[3];
-
-    float size;
-
-    enum nk_font_coord_type coord_type;
-
-    struct nk_vec2 spacing;
-
-    const nk_rune *range;
-
-    struct nk_baked_font *font;
-
-    nk_rune fallback_glyph;
-
-    struct nk_font_config *n;
-    struct nk_font_config *p;
-};
-
-struct nk_font_glyph {
-    nk_rune codepoint;
-    float xadvance;
-    float x0, y0, x1, y1, w, h;
-    float u0, v0, u1, v1;
-};
-
-struct nk_font {
-    struct nk_font *next;
-    struct nk_user_font handle;
-    struct nk_baked_font info;
-    float scale;
-    struct nk_font_glyph *glyphs;
-    const struct nk_font_glyph *fallback;
-    nk_rune fallback_codepoint;
-    nk_handle texture;
-    struct nk_font_config *config;
-};
-
-enum nk_font_atlas_format {
-    NK_FONT_ATLAS_ALPHA8,
-    NK_FONT_ATLAS_RGBA32
-};
-
-struct nk_font_atlas {
-    void *pixel;
-    int tex_width;
-    int tex_height;
-
-    struct nk_allocator permanent;
-    struct nk_allocator temporary;
-
-    struct nk_recti custom;
-    struct nk_cursor cursors[NK_CURSOR_COUNT];
-
-    int glyph_count;
-    struct nk_font_glyph *glyphs;
-    struct nk_font *default_font;
-    struct nk_font *fonts;
-    struct nk_font_config *config;
-    int font_num;
-};
-
-
-extern const nk_rune *nk_font_default_glyph_ranges(void);
-extern const nk_rune *nk_font_chinese_glyph_ranges(void);
-extern const nk_rune *nk_font_cyrillic_glyph_ranges(void);
-extern const nk_rune *nk_font_korean_glyph_ranges(void);
-
-
-extern void nk_font_atlas_init_default(struct nk_font_atlas*);
-
-extern void nk_font_atlas_init(struct nk_font_atlas*, struct nk_allocator*);
-extern void nk_font_atlas_init_custom(struct nk_font_atlas*, struct nk_allocator *persistent, struct nk_allocator *transient);
-extern void nk_font_atlas_begin(struct nk_font_atlas*);
-extern struct nk_font_config nk_font_config(float pixel_height);
-extern struct nk_font *nk_font_atlas_add(struct nk_font_atlas*, const struct nk_font_config*);
-
-
-
-extern struct nk_font* nk_font_atlas_add_from_memory(struct nk_font_atlas *atlas, void *memory, nk_size size, float height, const struct nk_font_config *config);
-
-
-
-extern struct nk_font *nk_font_atlas_add_compressed(struct nk_font_atlas*, void *memory, nk_size size, float height, const struct nk_font_config*);
-extern struct nk_font* nk_font_atlas_add_compressed_base85(struct nk_font_atlas*, const char *data, float height, const struct nk_font_config *config);
-extern const void* nk_font_atlas_bake(struct nk_font_atlas*, int *width, int *height, enum nk_font_atlas_format);
-extern void nk_font_atlas_end(struct nk_font_atlas*, nk_handle tex, struct nk_draw_null_texture*);
-extern const struct nk_font_glyph* nk_font_find_glyph(struct nk_font*, nk_rune unicode);
-extern void nk_font_atlas_cleanup(struct nk_font_atlas *atlas);
-extern void nk_font_atlas_clear(struct nk_font_atlas*);
-#line 2673
+# 4026 "nuklear/nuklear.h"
 struct nk_memory_status {
     void *memory;
     unsigned int type;
@@ -1335,7 +975,7 @@ extern void nk_buffer_free(struct nk_buffer*);
 extern void *nk_buffer_memory(struct nk_buffer*);
 extern const void *nk_buffer_memory_const(const struct nk_buffer*);
 extern nk_size nk_buffer_total(struct nk_buffer*);
-#line 2745
+# 4098 "nuklear/nuklear.h"
 struct nk_str {
     struct nk_buffer buffer;
     int len;
@@ -1381,7 +1021,7 @@ extern char *nk_str_get(struct nk_str*);
 extern const char *nk_str_get_const(const struct nk_str*);
 extern int nk_str_len(struct nk_str*);
 extern int nk_str_len_char(struct nk_str*);
-#line 2827
+# 4180 "nuklear/nuklear.h"
 struct nk_text_edit;
 struct nk_clipboard {
     nk_handle userdata;
@@ -1460,7 +1100,7 @@ extern int nk_textedit_cut(struct nk_text_edit*);
 extern int nk_textedit_paste(struct nk_text_edit*, char const*, int len);
 extern void nk_textedit_undo(struct nk_text_edit*);
 extern void nk_textedit_redo(struct nk_text_edit*);
-#line 2955
+# 4308 "nuklear/nuklear.h"
 enum nk_command_type {
     NK_COMMAND_NOP,
     NK_COMMAND_SCISSOR,
@@ -1732,8 +1372,9 @@ extern int nk_input_is_mouse_released(const struct nk_input*, enum nk_buttons);
 extern int nk_input_is_key_pressed(const struct nk_input*, enum nk_keys);
 extern int nk_input_is_key_released(const struct nk_input*, enum nk_keys);
 extern int nk_input_is_key_down(const struct nk_input*, enum nk_keys);
-#line 3246
+# 4602 "nuklear/nuklear.h"
 typedef nk_ushort nk_draw_index;
+
 enum nk_draw_list_stroke {
     NK_STROKE_OPEN = nk_false,
 
@@ -1823,14 +1464,12 @@ struct nk_draw_list {
 
 extern void nk_draw_list_init(struct nk_draw_list*);
 extern void nk_draw_list_setup(struct nk_draw_list*, const struct nk_convert_config*, struct nk_buffer *cmds, struct nk_buffer *vertices, struct nk_buffer *elements, enum nk_anti_aliasing line_aa,enum nk_anti_aliasing shape_aa);
-extern void nk_draw_list_clear(struct nk_draw_list*);
 
 
 
 extern const struct nk_draw_command* nk__draw_list_begin(const struct nk_draw_list*, const struct nk_buffer*);
 extern const struct nk_draw_command* nk__draw_list_next(const struct nk_draw_command*, const struct nk_buffer*, const struct nk_draw_list*);
 extern const struct nk_draw_command* nk__draw_list_end(const struct nk_draw_list*, const struct nk_buffer*);
-extern void nk_draw_list_clear(struct nk_draw_list *list);
 
 
 extern void nk_draw_list_path_clear(struct nk_draw_list*);
@@ -1860,7 +1499,7 @@ extern void nk_draw_list_fill_poly_convex(struct nk_draw_list*, const struct nk_
 
 extern void nk_draw_list_add_image(struct nk_draw_list*, struct nk_image texture, struct nk_rect rect, struct nk_color);
 extern void nk_draw_list_add_text(struct nk_draw_list*, const struct nk_user_font*, struct nk_rect, const char *text, int len, float font_height, struct nk_color);
-#line 3384
+# 4739 "nuklear/nuklear.h"
 enum nk_style_item_type {
     NK_STYLE_ITEM_COLOR,
     NK_STYLE_ITEM_IMAGE
@@ -2297,15 +1936,16 @@ struct nk_style {
 extern struct nk_style_item nk_style_item_image(struct nk_image img);
 extern struct nk_style_item nk_style_item_color(struct nk_color);
 extern struct nk_style_item nk_style_item_hide(void);
-#line 3831
+# 5186 "nuklear/nuklear.h"
 enum nk_panel_type {
-    NK_PANEL_WINDOW     = (1 << (0)),
-    NK_PANEL_GROUP      = (1 << (1)),
-    NK_PANEL_POPUP      = (1 << (2)),
+    NK_PANEL_NONE = 0,
+    NK_PANEL_WINDOW = (1 << (0)),
+    NK_PANEL_GROUP = (1 << (1)),
+    NK_PANEL_POPUP = (1 << (2)),
     NK_PANEL_CONTEXTUAL = (1 << (4)),
-    NK_PANEL_COMBO      = (1 << (5)),
-    NK_PANEL_MENU       = (1 << (6)),
-    NK_PANEL_TOOLTIP    = (1 << (7))
+    NK_PANEL_COMBO = (1 << (5)),
+    NK_PANEL_MENU = (1 << (6)),
+    NK_PANEL_TOOLTIP = (1 << (7))
 };
 enum nk_panel_set {
     NK_PANEL_SET_NONBLOCK = NK_PANEL_CONTEXTUAL|NK_PANEL_COMBO|NK_PANEL_MENU|NK_PANEL_TOOLTIP,
@@ -2388,23 +2028,23 @@ struct nk_panel {
     struct nk_command_buffer *buffer;
     struct nk_panel *parent;
 };
-#line 3929
+# 5285 "nuklear/nuklear.h"
 struct nk_table;
 enum nk_window_flags {
-    NK_WINDOW_PRIVATE       = (1 << (11)),
-    NK_WINDOW_DYNAMIC       = NK_WINDOW_PRIVATE,
+    NK_WINDOW_PRIVATE = (1 << (11)),
+    NK_WINDOW_DYNAMIC = NK_WINDOW_PRIVATE,
 
-    NK_WINDOW_ROM           = (1 << (12)),
+    NK_WINDOW_ROM = (1 << (12)),
 
     NK_WINDOW_NOT_INTERACTIVE = NK_WINDOW_ROM|NK_WINDOW_NO_INPUT,
 
-    NK_WINDOW_HIDDEN        = (1 << (13)),
+    NK_WINDOW_HIDDEN = (1 << (13)),
 
-    NK_WINDOW_CLOSED        = (1 << (14)),
+    NK_WINDOW_CLOSED = (1 << (14)),
 
-    NK_WINDOW_MINIMIZED     = (1 << (15)),
+    NK_WINDOW_MINIMIZED = (1 << (15)),
 
-    NK_WINDOW_REMOVE_ROM    = (1 << (16))
+    NK_WINDOW_REMOVE_ROM = (1 << (16))
 
 };
 
@@ -2472,22 +2112,22 @@ struct nk_window {
     struct nk_window *prev;
     struct nk_window *parent;
 };
-#line 4078
-struct nk_config_stack_style_item_element {        struct nk_style_item *address;        struct nk_style_item old_value;    };
-struct nk_config_stack_float_element {        float *address;        float old_value;    };
-struct nk_config_stack_vec2_element {        struct nk_vec2 *address;        struct nk_vec2 old_value;    };
-struct nk_config_stack_flags_element {        nk_flags *address;        nk_flags old_value;    };
-struct nk_config_stack_color_element {        struct nk_color *address;        struct nk_color old_value;    };
-struct nk_config_stack_user_font_element {        const struct nk_user_font* *address;        const struct nk_user_font* old_value;    };
-struct nk_config_stack_button_behavior_element {        enum nk_button_behavior *address;        enum nk_button_behavior old_value;    };
+# 5434 "nuklear/nuklear.h"
+struct nk_config_stack_style_item_element { struct nk_style_item *address; struct nk_style_item old_value; };
+struct nk_config_stack_float_element { float *address; float old_value; };
+struct nk_config_stack_vec2_element { struct nk_vec2 *address; struct nk_vec2 old_value; };
+struct nk_config_stack_flags_element { nk_flags *address; nk_flags old_value; };
+struct nk_config_stack_color_element { struct nk_color *address; struct nk_color old_value; };
+struct nk_config_stack_user_font_element { const struct nk_user_font* *address; const struct nk_user_font* old_value; };
+struct nk_config_stack_button_behavior_element { enum nk_button_behavior *address; enum nk_button_behavior old_value; };
 
-struct nk_config_stack_style_item {        int head;        struct nk_config_stack_style_item_element elements[16];    };
-struct nk_config_stack_float {        int head;        struct nk_config_stack_float_element elements[32];    };
-struct nk_config_stack_vec2 {        int head;        struct nk_config_stack_vec2_element elements[16];    };
-struct nk_config_stack_flags {        int head;        struct nk_config_stack_flags_element elements[32];    };
-struct nk_config_stack_color {        int head;        struct nk_config_stack_color_element elements[32];    };
-struct nk_config_stack_user_font {        int head;        struct nk_config_stack_user_font_element elements[8];    };
-struct nk_config_stack_button_behavior {        int head;        struct nk_config_stack_button_behavior_element elements[8];    };
+struct nk_config_stack_style_item { int head; struct nk_config_stack_style_item_element elements[16]; };
+struct nk_config_stack_float { int head; struct nk_config_stack_float_element elements[32]; };
+struct nk_config_stack_vec2 { int head; struct nk_config_stack_vec2_element elements[16]; };
+struct nk_config_stack_flags { int head; struct nk_config_stack_flags_element elements[32]; };
+struct nk_config_stack_color { int head; struct nk_config_stack_color_element elements[32]; };
+struct nk_config_stack_user_font { int head; struct nk_config_stack_user_font_element elements[8]; };
+struct nk_config_stack_button_behavior { int head; struct nk_config_stack_button_behavior_element elements[8]; };
 
 struct nk_configuration_stacks {
     struct nk_config_stack_style_item style_items;
@@ -2498,7 +2138,13 @@ struct nk_configuration_stacks {
     struct nk_config_stack_user_font fonts;
     struct nk_config_stack_button_behavior button_behaviors;
 };
-#line 4110
+
+
+
+
+
+
+
 struct nk_table {
     unsigned int seq;
     unsigned int size;
@@ -2552,7 +2198,7 @@ struct nk_context {
 
 
     struct nk_draw_list draw_list;
-#line 4171
+# 5527 "nuklear/nuklear.h"
     struct nk_text_edit text_edit;
 
     struct nk_command_buffer overlay;

--- a/nuklear_preprocessed.h
+++ b/nuklear_preprocessed.h
@@ -4,10 +4,10 @@ typedef unsigned char nk_uchar;
 typedef unsigned char nk_byte;
 typedef signed short nk_short;
 typedef unsigned short nk_ushort;
-typedef int nk_int;
+typedef signed int nk_int;
 typedef unsigned int nk_uint;
-typedef unsigned int nk_size;
-typedef unsigned int nk_ptr;
+typedef unsigned long nk_size;
+typedef unsigned long nk_ptr;
 
 typedef nk_uint nk_hash;
 typedef nk_uint nk_flags;
@@ -70,18 +70,18 @@ struct nk_image {nk_handle handle;unsigned short w,h;unsigned short region[4];};
 struct nk_cursor {struct nk_image img; struct nk_vec2 size, offset;};
 struct nk_scroll {nk_uint x, y;};
 
-enum nk_heading {NK_UP, NK_RIGHT, NK_DOWN, NK_LEFT};
+enum nk_heading         {NK_UP, NK_RIGHT, NK_DOWN, NK_LEFT};
 enum nk_button_behavior {NK_BUTTON_DEFAULT, NK_BUTTON_REPEATER};
-enum nk_modify {NK_FIXED = nk_false, NK_MODIFIABLE = nk_true};
-enum nk_orientation {NK_VERTICAL, NK_HORIZONTAL};
+enum nk_modify          {NK_FIXED = nk_false, NK_MODIFIABLE = nk_true};
+enum nk_orientation     {NK_VERTICAL, NK_HORIZONTAL};
 enum nk_collapse_states {NK_MINIMIZED = nk_false, NK_MAXIMIZED = nk_true};
-enum nk_show_states {NK_HIDDEN = nk_false, NK_SHOWN = nk_true};
-enum nk_chart_type {NK_CHART_LINES, NK_CHART_COLUMN, NK_CHART_MAX};
-enum nk_chart_event {NK_CHART_HOVERING = 0x01, NK_CHART_CLICKED = 0x02};
-enum nk_color_format {NK_RGB, NK_RGBA};
-enum nk_popup_type {NK_POPUP_STATIC, NK_POPUP_DYNAMIC};
-enum nk_layout_format {NK_DYNAMIC, NK_STATIC};
-enum nk_tree_type {NK_TREE_NODE, NK_TREE_TAB};
+enum nk_show_states     {NK_HIDDEN = nk_false, NK_SHOWN = nk_true};
+enum nk_chart_type      {NK_CHART_LINES, NK_CHART_COLUMN, NK_CHART_MAX};
+enum nk_chart_event     {NK_CHART_HOVERING = 0x01, NK_CHART_CLICKED = 0x02};
+enum nk_color_format    {NK_RGB, NK_RGBA};
+enum nk_popup_type      {NK_POPUP_STATIC, NK_POPUP_DYNAMIC};
+enum nk_layout_format   {NK_DYNAMIC, NK_STATIC};
+enum nk_tree_type       {NK_TREE_NODE, NK_TREE_TAB};
 
 typedef void*(*nk_plugin_alloc)(nk_handle, void *old, nk_size);
 typedef void (*nk_plugin_free)(nk_handle, void *old);
@@ -268,17 +268,17 @@ extern const struct nk_draw_command* nk__draw_end(const struct nk_context*, cons
 extern const struct nk_draw_command* nk__draw_next(const struct nk_draw_command*, const struct nk_buffer*, const struct nk_context*);
 #line 1181
 enum nk_panel_flags {
-    NK_WINDOW_BORDER = (1 << (0)),
-    NK_WINDOW_MOVABLE = (1 << (1)),
-    NK_WINDOW_SCALABLE = (1 << (2)),
-    NK_WINDOW_CLOSABLE = (1 << (3)),
-    NK_WINDOW_MINIMIZABLE = (1 << (4)),
-    NK_WINDOW_NO_SCROLLBAR = (1 << (5)),
-    NK_WINDOW_TITLE = (1 << (6)),
-    NK_WINDOW_SCROLL_AUTO_HIDE = (1 << (7)),
-    NK_WINDOW_BACKGROUND = (1 << (8)),
-    NK_WINDOW_SCALE_LEFT = (1 << (9)),
-    NK_WINDOW_NO_INPUT = (1 << (10))
+    NK_WINDOW_BORDER            = (1 << (0)),
+    NK_WINDOW_MOVABLE           = (1 << (1)),
+    NK_WINDOW_SCALABLE          = (1 << (2)),
+    NK_WINDOW_CLOSABLE          = (1 << (3)),
+    NK_WINDOW_MINIMIZABLE       = (1 << (4)),
+    NK_WINDOW_NO_SCROLLBAR      = (1 << (5)),
+    NK_WINDOW_TITLE             = (1 << (6)),
+    NK_WINDOW_SCROLL_AUTO_HIDE  = (1 << (7)),
+    NK_WINDOW_BACKGROUND        = (1 << (8)),
+    NK_WINDOW_SCALE_LEFT        = (1 << (9)),
+    NK_WINDOW_NO_INPUT          = (1 << (10))
 };
 #line 1202
 extern int nk_begin(struct nk_context *ctx, const char *title, struct nk_rect bounds, nk_flags flags);
@@ -631,14 +631,14 @@ enum nk_widget_layout_states {
     NK_WIDGET_ROM
 };
 enum nk_widget_states {
-    NK_WIDGET_STATE_MODIFIED = (1 << (1)),
-    NK_WIDGET_STATE_INACTIVE = (1 << (2)),
-    NK_WIDGET_STATE_ENTERED = (1 << (3)),
-    NK_WIDGET_STATE_HOVER = (1 << (4)),
-    NK_WIDGET_STATE_ACTIVED = (1 << (5)),
-    NK_WIDGET_STATE_LEFT = (1 << (6)),
-    NK_WIDGET_STATE_HOVERED = NK_WIDGET_STATE_HOVER|NK_WIDGET_STATE_MODIFIED,
-    NK_WIDGET_STATE_ACTIVE = NK_WIDGET_STATE_ACTIVED|NK_WIDGET_STATE_MODIFIED
+    NK_WIDGET_STATE_MODIFIED    = (1 << (1)),
+    NK_WIDGET_STATE_INACTIVE    = (1 << (2)),
+    NK_WIDGET_STATE_ENTERED     = (1 << (3)),
+    NK_WIDGET_STATE_HOVER       = (1 << (4)),
+    NK_WIDGET_STATE_ACTIVED     = (1 << (5)),
+    NK_WIDGET_STATE_LEFT        = (1 << (6)),
+    NK_WIDGET_STATE_HOVERED     = NK_WIDGET_STATE_HOVER|NK_WIDGET_STATE_MODIFIED,
+    NK_WIDGET_STATE_ACTIVE      = NK_WIDGET_STATE_ACTIVED|NK_WIDGET_STATE_MODIFIED
 };
 extern enum nk_widget_layout_states nk_widget(struct nk_rect*, const struct nk_context*);
 extern enum nk_widget_layout_states nk_widget_fitting(struct nk_rect*, struct nk_context*, struct nk_vec2);
@@ -657,17 +657,17 @@ extern void nk_spacing(struct nk_context*, int cols);
 
 
 enum nk_text_align {
-    NK_TEXT_ALIGN_LEFT = 0x01,
-    NK_TEXT_ALIGN_CENTERED = 0x02,
-    NK_TEXT_ALIGN_RIGHT = 0x04,
-    NK_TEXT_ALIGN_TOP = 0x08,
-    NK_TEXT_ALIGN_MIDDLE = 0x10,
-    NK_TEXT_ALIGN_BOTTOM = 0x20
+    NK_TEXT_ALIGN_LEFT        = 0x01,
+    NK_TEXT_ALIGN_CENTERED    = 0x02,
+    NK_TEXT_ALIGN_RIGHT       = 0x04,
+    NK_TEXT_ALIGN_TOP         = 0x08,
+    NK_TEXT_ALIGN_MIDDLE      = 0x10,
+    NK_TEXT_ALIGN_BOTTOM      = 0x20
 };
 enum nk_text_alignment {
-    NK_TEXT_LEFT = NK_TEXT_ALIGN_MIDDLE|NK_TEXT_ALIGN_LEFT,
-    NK_TEXT_CENTERED = NK_TEXT_ALIGN_MIDDLE|NK_TEXT_ALIGN_CENTERED,
-    NK_TEXT_RIGHT = NK_TEXT_ALIGN_MIDDLE|NK_TEXT_ALIGN_RIGHT
+    NK_TEXT_LEFT        = NK_TEXT_ALIGN_MIDDLE|NK_TEXT_ALIGN_LEFT,
+    NK_TEXT_CENTERED    = NK_TEXT_ALIGN_MIDDLE|NK_TEXT_ALIGN_CENTERED,
+    NK_TEXT_RIGHT       = NK_TEXT_ALIGN_MIDDLE|NK_TEXT_ALIGN_RIGHT
 };
 extern void nk_text(struct nk_context*, const char*, int, nk_flags);
 extern void nk_text_colored(struct nk_context*, const char*, int, nk_flags, struct nk_color);
@@ -745,7 +745,7 @@ extern int nk_option_text(struct nk_context*, const char*, int, int active);
 
 extern int nk_selectable_label(struct nk_context*, const char*, nk_flags align, int *value);
 extern int nk_selectable_text(struct nk_context*, const char*, int, nk_flags align, int *value);
-extern int nk_selectable_image_label(struct nk_context*,struct nk_image, const char*, nk_flags align, int *value);
+extern int nk_selectable_image_label(struct nk_context*,struct nk_image,  const char*, nk_flags align, int *value);
 extern int nk_selectable_image_text(struct nk_context*,struct nk_image, const char*, int, nk_flags align, int *value);
 extern int nk_select_label(struct nk_context*, const char*, nk_flags align, int value);
 extern int nk_select_text(struct nk_context*, const char*, int, nk_flags align, int value);
@@ -792,32 +792,32 @@ extern double nk_propertyd(struct nk_context*, const char *name, double min, dou
 
 
 enum nk_edit_flags {
-    NK_EDIT_DEFAULT = 0,
-    NK_EDIT_READ_ONLY = (1 << (0)),
-    NK_EDIT_AUTO_SELECT = (1 << (1)),
-    NK_EDIT_SIG_ENTER = (1 << (2)),
-    NK_EDIT_ALLOW_TAB = (1 << (3)),
-    NK_EDIT_NO_CURSOR = (1 << (4)),
-    NK_EDIT_SELECTABLE = (1 << (5)),
-    NK_EDIT_CLIPBOARD = (1 << (6)),
-    NK_EDIT_CTRL_ENTER_NEWLINE = (1 << (7)),
-    NK_EDIT_NO_HORIZONTAL_SCROLL = (1 << (8)),
-    NK_EDIT_ALWAYS_INSERT_MODE = (1 << (9)),
-    NK_EDIT_MULTILINE = (1 << (10)),
-    NK_EDIT_GOTO_END_ON_ACTIVATE = (1 << (11))
+    NK_EDIT_DEFAULT                 = 0,
+    NK_EDIT_READ_ONLY               = (1 << (0)),
+    NK_EDIT_AUTO_SELECT             = (1 << (1)),
+    NK_EDIT_SIG_ENTER               = (1 << (2)),
+    NK_EDIT_ALLOW_TAB               = (1 << (3)),
+    NK_EDIT_NO_CURSOR               = (1 << (4)),
+    NK_EDIT_SELECTABLE              = (1 << (5)),
+    NK_EDIT_CLIPBOARD               = (1 << (6)),
+    NK_EDIT_CTRL_ENTER_NEWLINE      = (1 << (7)),
+    NK_EDIT_NO_HORIZONTAL_SCROLL    = (1 << (8)),
+    NK_EDIT_ALWAYS_INSERT_MODE      = (1 << (9)),
+    NK_EDIT_MULTILINE               = (1 << (10)),
+    NK_EDIT_GOTO_END_ON_ACTIVATE    = (1 << (11))
 };
 enum nk_edit_types {
-    NK_EDIT_SIMPLE = NK_EDIT_ALWAYS_INSERT_MODE,
-    NK_EDIT_FIELD = NK_EDIT_SIMPLE|NK_EDIT_SELECTABLE|NK_EDIT_CLIPBOARD,
-    NK_EDIT_BOX = NK_EDIT_ALWAYS_INSERT_MODE| NK_EDIT_SELECTABLE| NK_EDIT_MULTILINE|NK_EDIT_ALLOW_TAB|NK_EDIT_CLIPBOARD,
-    NK_EDIT_EDITOR = NK_EDIT_SELECTABLE|NK_EDIT_MULTILINE|NK_EDIT_ALLOW_TAB| NK_EDIT_CLIPBOARD
+    NK_EDIT_SIMPLE  = NK_EDIT_ALWAYS_INSERT_MODE,
+    NK_EDIT_FIELD   = NK_EDIT_SIMPLE|NK_EDIT_SELECTABLE|NK_EDIT_CLIPBOARD,
+    NK_EDIT_BOX     = NK_EDIT_ALWAYS_INSERT_MODE| NK_EDIT_SELECTABLE| NK_EDIT_MULTILINE|NK_EDIT_ALLOW_TAB|NK_EDIT_CLIPBOARD,
+    NK_EDIT_EDITOR  = NK_EDIT_SELECTABLE|NK_EDIT_MULTILINE|NK_EDIT_ALLOW_TAB| NK_EDIT_CLIPBOARD
 };
 enum nk_edit_events {
-    NK_EDIT_ACTIVE = (1 << (0)),
-    NK_EDIT_INACTIVE = (1 << (1)),
-    NK_EDIT_ACTIVATED = (1 << (2)),
+    NK_EDIT_ACTIVE      = (1 << (0)),
+    NK_EDIT_INACTIVE    = (1 << (1)),
+    NK_EDIT_ACTIVATED   = (1 << (2)),
     NK_EDIT_DEACTIVATED = (1 << (3)),
-    NK_EDIT_COMMITED = (1 << (4))
+    NK_EDIT_COMMITED    = (1 << (4))
 };
 extern nk_flags nk_edit_string(struct nk_context*, nk_flags, char *buffer, int *len, int max, nk_plugin_filter);
 extern nk_flags nk_edit_string_zero_terminated(struct nk_context*, nk_flags, char *buffer, int max, nk_plugin_filter);
@@ -867,12 +867,12 @@ extern void nk_combobox_callback(struct nk_context*, void(*item_getter)(void*, i
 extern int nk_combo_begin_text(struct nk_context*, const char *selected, int, struct nk_vec2 size);
 extern int nk_combo_begin_label(struct nk_context*, const char *selected, struct nk_vec2 size);
 extern int nk_combo_begin_color(struct nk_context*, struct nk_color color, struct nk_vec2 size);
-extern int nk_combo_begin_symbol(struct nk_context*, enum nk_symbol_type, struct nk_vec2 size);
+extern int nk_combo_begin_symbol(struct nk_context*,  enum nk_symbol_type,  struct nk_vec2 size);
 extern int nk_combo_begin_symbol_label(struct nk_context*, const char *selected, enum nk_symbol_type, struct nk_vec2 size);
 extern int nk_combo_begin_symbol_text(struct nk_context*, const char *selected, int, enum nk_symbol_type, struct nk_vec2 size);
-extern int nk_combo_begin_image(struct nk_context*, struct nk_image img, struct nk_vec2 size);
+extern int nk_combo_begin_image(struct nk_context*, struct nk_image img,  struct nk_vec2 size);
 extern int nk_combo_begin_image_label(struct nk_context*, const char *selected, struct nk_image, struct nk_vec2 size);
-extern int nk_combo_begin_image_text(struct nk_context*, const char *selected, int, struct nk_image, struct nk_vec2 size);
+extern int nk_combo_begin_image_text(struct nk_context*,  const char *selected, int, struct nk_image, struct nk_vec2 size);
 extern int nk_combo_item_label(struct nk_context*, const char*, nk_flags alignment);
 extern int nk_combo_item_text(struct nk_context*, const char*,int, nk_flags alignment);
 extern int nk_combo_item_image_label(struct nk_context*, struct nk_image, const char*, nk_flags alignment);
@@ -2299,13 +2299,13 @@ extern struct nk_style_item nk_style_item_color(struct nk_color);
 extern struct nk_style_item nk_style_item_hide(void);
 #line 3831
 enum nk_panel_type {
-    NK_PANEL_WINDOW = (1 << (0)),
-    NK_PANEL_GROUP = (1 << (1)),
-    NK_PANEL_POPUP = (1 << (2)),
+    NK_PANEL_WINDOW     = (1 << (0)),
+    NK_PANEL_GROUP      = (1 << (1)),
+    NK_PANEL_POPUP      = (1 << (2)),
     NK_PANEL_CONTEXTUAL = (1 << (4)),
-    NK_PANEL_COMBO = (1 << (5)),
-    NK_PANEL_MENU = (1 << (6)),
-    NK_PANEL_TOOLTIP = (1 << (7))
+    NK_PANEL_COMBO      = (1 << (5)),
+    NK_PANEL_MENU       = (1 << (6)),
+    NK_PANEL_TOOLTIP    = (1 << (7))
 };
 enum nk_panel_set {
     NK_PANEL_SET_NONBLOCK = NK_PANEL_CONTEXTUAL|NK_PANEL_COMBO|NK_PANEL_MENU|NK_PANEL_TOOLTIP,
@@ -2391,20 +2391,20 @@ struct nk_panel {
 #line 3929
 struct nk_table;
 enum nk_window_flags {
-    NK_WINDOW_PRIVATE = (1 << (11)),
-    NK_WINDOW_DYNAMIC = NK_WINDOW_PRIVATE,
+    NK_WINDOW_PRIVATE       = (1 << (11)),
+    NK_WINDOW_DYNAMIC       = NK_WINDOW_PRIVATE,
 
-    NK_WINDOW_ROM = (1 << (12)),
+    NK_WINDOW_ROM           = (1 << (12)),
 
     NK_WINDOW_NOT_INTERACTIVE = NK_WINDOW_ROM|NK_WINDOW_NO_INPUT,
 
-    NK_WINDOW_HIDDEN = (1 << (13)),
+    NK_WINDOW_HIDDEN        = (1 << (13)),
 
-    NK_WINDOW_CLOSED = (1 << (14)),
+    NK_WINDOW_CLOSED        = (1 << (14)),
 
-    NK_WINDOW_MINIMIZED = (1 << (15)),
+    NK_WINDOW_MINIMIZED     = (1 << (15)),
 
-    NK_WINDOW_REMOVE_ROM = (1 << (16))
+    NK_WINDOW_REMOVE_ROM    = (1 << (16))
 
 };
 
@@ -2473,21 +2473,21 @@ struct nk_window {
     struct nk_window *parent;
 };
 #line 4078
-struct nk_config_stack_style_item_element { struct nk_style_item *address; struct nk_style_item old_value; };
-struct nk_config_stack_float_element { float *address; float old_value; };
-struct nk_config_stack_vec2_element { struct nk_vec2 *address; struct nk_vec2 old_value; };
-struct nk_config_stack_flags_element { nk_flags *address; nk_flags old_value; };
-struct nk_config_stack_color_element { struct nk_color *address; struct nk_color old_value; };
-struct nk_config_stack_user_font_element { const struct nk_user_font* *address; const struct nk_user_font* old_value; };
-struct nk_config_stack_button_behavior_element { enum nk_button_behavior *address; enum nk_button_behavior old_value; };
+struct nk_config_stack_style_item_element {        struct nk_style_item *address;        struct nk_style_item old_value;    };
+struct nk_config_stack_float_element {        float *address;        float old_value;    };
+struct nk_config_stack_vec2_element {        struct nk_vec2 *address;        struct nk_vec2 old_value;    };
+struct nk_config_stack_flags_element {        nk_flags *address;        nk_flags old_value;    };
+struct nk_config_stack_color_element {        struct nk_color *address;        struct nk_color old_value;    };
+struct nk_config_stack_user_font_element {        const struct nk_user_font* *address;        const struct nk_user_font* old_value;    };
+struct nk_config_stack_button_behavior_element {        enum nk_button_behavior *address;        enum nk_button_behavior old_value;    };
 
-struct nk_config_stack_style_item { int head; struct nk_config_stack_style_item_element elements[16]; };
-struct nk_config_stack_float { int head; struct nk_config_stack_float_element elements[32]; };
-struct nk_config_stack_vec2 { int head; struct nk_config_stack_vec2_element elements[16]; };
-struct nk_config_stack_flags { int head; struct nk_config_stack_flags_element elements[32]; };
-struct nk_config_stack_color { int head; struct nk_config_stack_color_element elements[32]; };
-struct nk_config_stack_user_font { int head; struct nk_config_stack_user_font_element elements[8]; };
-struct nk_config_stack_button_behavior { int head; struct nk_config_stack_button_behavior_element elements[8]; };
+struct nk_config_stack_style_item {        int head;        struct nk_config_stack_style_item_element elements[16];    };
+struct nk_config_stack_float {        int head;        struct nk_config_stack_float_element elements[32];    };
+struct nk_config_stack_vec2 {        int head;        struct nk_config_stack_vec2_element elements[16];    };
+struct nk_config_stack_flags {        int head;        struct nk_config_stack_flags_element elements[32];    };
+struct nk_config_stack_color {        int head;        struct nk_config_stack_color_element elements[32];    };
+struct nk_config_stack_user_font {        int head;        struct nk_config_stack_user_font_element elements[8];    };
+struct nk_config_stack_button_behavior {        int head;        struct nk_config_stack_button_behavior_element elements[8];    };
 
 struct nk_configuration_stacks {
     struct nk_config_stack_style_item style_items;

--- a/pynk/build.py
+++ b/pynk/build.py
@@ -171,9 +171,11 @@ def maker():
         preprocessed_text = open(
             cached_preprocessed_header_filename, 'rU').read()
     else:
-        print("Preprocessing header...")
-        preprocessed_text = run_c_preprocessor(header_only_options + header)
-        open(cached_preprocessed_header_filename, 'w').write(preprocessed_text)
+        print("Ensure that you have gcc and sed installed, then run make to generate header")
+        raise NotImplemented
+        #print("Preprocessing header...")
+        #preprocessed_text = run_c_preprocessor(header_only_options + header)
+        #open(cached_preprocessed_header_filename, 'w').write(preprocessed_text)
 
     # Extract the 'cdef' text from the header file.
     defs = build_nuklear_defs(preprocessed_text, extra_cdef)

--- a/pynk/nkpygame.py
+++ b/pynk/nkpygame.py
@@ -245,7 +245,7 @@ class NkPygame(object):
                 if unicodedata.category(e.unicode)[0] != "C":
                     char = str(e.unicode)
                     if len(char) == 1:
-                        lib.nk_input_char(self.ctx, str(e.unicode))
+                        lib.nk_input_char(self.ctx, str(e.unicode).encode('utf-8'))
         elif e.type == pygame.MOUSEBUTTONDOWN or e.type == pygame.MOUSEBUTTONUP:
             down = e.type == pygame.MOUSEBUTTONDOWN
             button = lib.NK_BUTTON_LEFT

--- a/pynk/nkpygame.py
+++ b/pynk/nkpygame.py
@@ -254,6 +254,11 @@ class NkPygame(object):
             elif e.button == 3:
                 button = lib.NK_BUTTON_RIGHT
             lib.nk_input_button(self.ctx, button, e.pos[0], e.pos[1], down)
+            # calculate scrolling vector
+            scroll_vect = lib.nk_vec2(0,0);
+            scroll_vect.x = (e.button == 7)*-1 + (e.button == 6)
+            scroll_vect.y = (e.button == 4) + (e.button == 5)*-1
+            lib.nk_input_scroll(self.ctx, scroll_vect)
         elif e.type == pygame.MOUSEMOTION:
             lib.nk_input_motion(self.ctx, e.pos[0], e.pos[1])
 

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ Setup script for 'pynk' library.
 from setuptools import setup
 
 setup(name='pynk',
-      version=open("VERSION", "rU").read().strip(),
+      version=open("VERSION", "r").read().strip(),
       description='Python integration of the \'nuklear\' C library.',
-      long_description=open("README.rst", "rU").read(),
+      long_description=open("README.rst", "r").read(),
       url='http://github.com/nathanrw/nuklear-cffi',
       author='Nathan Woodward',
       author_email='nathanrichardwoodward@gmail.com',


### PR DESCRIPTION
Everything except the overview translated to python seems to work
perfectly. The biggest change between versions was that now with
every string on cffi you have to do "test".encode('utf-8') instead
of just using a string in a cffi function like "test". I have not
found a way to mitigate this issue so far. This change in encoding
practice with cffi is the source of almost all breaking in
overview.py. I used a vim regex command to add encode('utf-8') to
all strings that aren't doc strings, but there are several issues
still present and undiscovered, and can only be discovered by
running overview and pressing on random buttons.